### PR TITLE
Fix Codespaces stall: use fault-tolerant post-create wrapper

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
       "version": "20"
     }
   },
-  "postCreateCommand": "curl -LsSf https://astral.sh/uv/install.sh | sh && export PATH=\"$HOME/.local/bin:$PATH\" && ./scripts/setup.sh",
+  "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Post-create setup for GitHub Codespaces
+#
+# This wrapper ensures the Codespace always becomes "ready" even if
+# setup.sh encounters errors. Without this, any failure in the &&-chained
+# postCreateCommand causes the Codespace to appear permanently stuck.
+
+echo "=== Installing uv package manager ==="
+curl -LsSf https://astral.sh/uv/install.sh | sh || {
+    echo "WARNING: uv installation failed — continuing without it"
+}
+
+# Add uv to PATH for this session
+export PATH="$HOME/.local/bin:$PATH"
+
+echo ""
+echo "=== Running project setup ==="
+
+# Prevent git from hanging on credential prompts for cloned repos
+export GIT_TERMINAL_PROMPT=0
+
+if ./scripts/setup.sh; then
+    echo ""
+    echo "Setup completed successfully!"
+else
+    echo ""
+    echo "============================================"
+    echo "  Setup encountered errors (see above)."
+    echo "  Your Codespace is still usable."
+    echo "  Re-run to retry:  ./scripts/setup.sh"
+    echo "============================================"
+    echo ""
+fi


### PR DESCRIPTION
The Codespace was stalling because postCreateCommand used a fragile &&-chain. If setup.sh failed (set -e on any npm/pip error), the chain returned non-zero and the Codespace never reached "ready" state.

Fix:
- Add .devcontainer/post-create.sh wrapper that always exits 0
- Set GIT_TERMINAL_PROMPT=0 to prevent git clone credential hangs
- Catch setup.sh failures gracefully with a re-run message
- Codespace now opens even if MCP server setup has issues

https://claude.ai/code/session_017WPuduD4kANnnKWdFpLMzb