### PR TITLE
Switch to pre-cached universal devcontainer image

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,6 @@
 {
   "name": "Civic AI Tools",
-  "image": "mcr.microsoft.com/devcontainers/python:3.12",
-  "features": {
-    "ghcr.io/devcontainers/features/node:1": {
-      "version": "20"
-    }
-  },
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {
     "vscode": {


### PR DESCRIPTION
The python:3.12 image + Node.js feature required a full container build that was timing out ("Building codespace..." stall, then ECONNABORTED). The universal:2 image is pre-cached on Codespaces and already includes Python 3.12 and Node.js 20, so the container starts instantly with no build step.

https://claude.ai/code/session_017WPuduD4kANnnKWdFpLMzb