### PR TITLE
Fix Codespaces ECONNABORTED: use lightweight Python image instead of …

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,1 +1,10 @@
-{}
+{
+  "name": "Civic AI Tools",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    }
+  },
+  "postCreateCommand": "bash .devcontainer/post-create.sh"
+}


### PR DESCRIPTION
…default universal

The empty devcontainer.json ({}) caused GitHub to use the ~12GB universal image. If not pre-cached in the user's region, pulling it exceeds the connection timeout, resulting in ECONNABORTED: canceled.

Switch to the ~1GB python:3.12 image with Node.js as a feature, and re-enable postCreateCommand to run the fault-tolerant post-create.sh.

https://claude.ai/code/session_01HvWmnM9Je2Eh2bogVYcZQk