### PR TITLE
Support multi-turn capture + blob refs in publish-evidence skill

### DIFF
--- a/.claude/skills/publish-evidence/SKILL.md
+++ b/.claude/skills/publish-evidence/SKILL.md
@@ -19,6 +19,41 @@ The user has just finished an analysis in this session using the Socrata MCP ser
 
 Do **not** invoke this skill for analyses the user has not asked to publish, or for non-civic conversations (code questions, chit-chat, etc.). Do not invoke it to re-publish a package that was already published in this session; just quote the URL from the prior turn.
 
+## Capture modes
+
+The skill supports two capture modes. Pick the one that matches what the user said, set `captureMode` in the JSON payload, and proceed.
+
+| Mode | When to choose it | What gets captured |
+|------|-------------------|---------------------|
+| `single_final_turn` (default) | "publish this as evidence", "publish this analysis", "sign this answer" — the user points at a single question → answer cycle. | The last user prompt, the final assistant markdown response, and every civic MCP tool call made to answer it. Matches the website chat-flow shape. |
+| `full_conversation` | "publish this whole session", "publish the full conversation", "include every turn", "publish everything we did" — the user wants the multi-turn record. | Every captured turn since the civic analysis started, rendered as a markdown transcript in `output`, plus every civic MCP tool call across those turns. Emits a structured turn list in `extensions["org.civicaitools.multi-turn"]`. |
+
+If the user's phrasing is ambiguous (e.g., "publish this"), default to `single_final_turn` and confirm with the user before proceeding: *"Publishing just this final answer. Want the whole multi-turn session instead?"*
+
+Modes can also be overridden at the command line with `--mode single_final_turn|full_conversation`, which takes precedence over the payload field. Don't use the flag in the Claude-driven flow; set the payload field instead.
+
+### Session-boundary convention (full_conversation only)
+
+Default capture starts at the **first Socrata or Data Commons MCP tool call** in the session, not at session start. Claude Code sessions often include unrelated setup before the user pivots to civic data; capturing from session start bundles noise into the evidence record.
+
+The user can override this by saying something like "publish from the beginning of the session" or "include everything before the first tool call too." If overriding, **confirm with the user before proceeding** — session-start capture may include content the user didn't realise would be published. Record the chosen boundary in the payload as `sessionBoundary: "first_civic_tool_call"` (default) or `sessionBoundary: "session_start"`.
+
+### Prompt-field selection (multi-turn)
+
+Default: the first user message in the captured window becomes `prompt`. If that turn is clearly setup or clarification and a later turn carries the real analysis question ("ok now compare that to the Bronx", etc.), **promote the later turn to `prompt`** and keep the earlier context in the transcript. Either way, `prompt` should reflect the semantic analysis question, not a greeting or clarification.
+
+### Turn roles
+
+Use exactly these three values for `turns[].role`:
+
+- `"user"` — a user message
+- `"assistant"` — an assistant message
+- `"tool"` — a tool result (when captured separately; usually tool results fold into the adjacent assistant turn)
+
+### Token usage (multi-turn)
+
+Sum `promptTokens` + `completionTokens` across **all captured turns**, not just the final turn. The evidence package's cost attribution reflects the full analysis cost; partial token accounting would misrepresent the dogfooded workload.
+
 ## Prerequisites
 
 Before posting, confirm these are all true. If any is missing, ask the user before proceeding.
@@ -31,7 +66,7 @@ Before posting, confirm these are all true. If any is missing, ask the user befo
 
 2. **The analysis actually ran.** There must be at least one Socrata or Data Commons MCP tool call earlier in this conversation with a real result. Do not publish hypothetical or placeholder analyses.
 
-3. **A concrete final response exists.** The assistant's answer to the user's original civic question should be present in the conversation and reflect what the tool calls returned. If the prior response punted on indicators or flagged data-quality issues, that's fine — publish it verbatim; the attestation flow on civicaitools.org surfaces partial completions.
+3. **A concrete final response exists** (or, in multi-turn mode, a coherent transcript). Publish what was actually said verbatim — partial completions and flagged uncertainties are fine; the attestation flow on civicaitools.org surfaces them.
 
 ## Inputs to assemble
 
@@ -41,31 +76,43 @@ You are assembling a JSON payload that you will pass to the bundled `publish.py`
 |------|--------|
 | `title` | A short, specific name for the analysis (≤80 chars, shown on the evidence detail page and in the URL slug). Derive from the user's original question. Ask the user to confirm. |
 | `summary` | 2–4 sentences for a non-technical reader. Neutral third-person voice (never "I" or "we"). Describe what was analyzed, what the key finding was, and any caveats or partial results. |
-| `prompt` | The user's original analysis question, verbatim — the question that kicked off the tool calls. NOT the follow-up "publish this". |
-| `output` | The assistant's final markdown response to the analysis question. Verbatim; preserve tables, citations, caveats, flagged uncertainties. |
+| `captureMode` | `"single_final_turn"` (default) or `"full_conversation"`. See "Capture modes" above. |
+| `prompt` | Single-turn: the user's original analysis question, verbatim. Multi-turn: the first user message in the captured window, OR a later semantic analysis question if the first turn is setup/clarification. Never a "publish this" follow-up. |
+| `output` | Single-turn: the assistant's final markdown response verbatim. Multi-turn: a rendered markdown transcript of every captured turn with `### Turn N — User` / `### Turn N — Assistant` headers (matching `turns[].index` and `turns[].role`). Preserve tables, citations, and caveats. |
+| `turns[]` | Required when `captureMode` is `full_conversation`. Array of `{ index, role, content }` objects, strictly increasing `index`. Roles are `user`, `assistant`, or `tool`. See "Turn roles" above. |
+| `sessionBoundary` | Optional, full_conversation only. `"first_civic_tool_call"` (default) or `"session_start"`. Confirm with the user before setting to `session_start`. |
 | `model` | `anthropic/claude-opus-4-7` if you are Claude Opus 4.7 ("Opus 4.7" appears in the session's model identifier). Use the exact model slug from the current session. |
 | `portal` | `data.cityofnewyork.us` if any Socrata tool calls used NYC Open Data; otherwise the portal used; otherwise `n/a` for Data-Commons-only analyses. |
 | `promptVisibility` | `full_text` by default — the prompt goes into the package in the clear. Switch to `hash_only` only if the user explicitly asks to omit their prompt text. |
-| `tokenUsage.promptTokens`, `tokenUsage.completionTokens` | Best available estimates. If you cannot reasonably estimate, omit the inner fields (send an empty `{}`); the server accepts that. |
-| `duration_ms` | Rough end-to-end analysis wall-clock in milliseconds. If unknown, omit. |
-| `toolCalls[]` | One entry per MCP tool call made in the analysis — see below. |
+| `tokenUsage.promptTokens`, `tokenUsage.completionTokens` | Single-turn: best available estimates for the one turn. Multi-turn: **sum across all captured turns**. If you cannot reasonably estimate, omit the inner fields (send an empty `{}`). |
+| `duration_ms` | Rough end-to-end wall-clock in milliseconds (single-turn) or the span of the captured turns (multi-turn). If unknown, omit. |
+| `toolCalls[]` | One entry per civic MCP tool call made in the captured window — see below. |
 
 ### `toolCalls[]` reconstruction
 
-Walk through every tool call in this conversation's context. For each one, add an entry:
+Walk through every tool call in the captured window. For each one, add an entry:
 
-- `name` — the underlying MCP tool name. Strip any `mcp__socrata__` / `mcp__data-commons__` prefix before populating (e.g., `mcp__socrata__get_data` → `get_data`, `mcp__data-commons__search_indicators` → `search_indicators`).
+- `name` — the underlying MCP tool name. Strip any `mcp__socrata__` / `mcp__data-commons__` prefix (e.g., `mcp__socrata__get_data` → `get_data`, `mcp__data-commons__search_indicators` → `search_indicators`).
 - `source` — `"socrata"` or `"data-commons"` based on the tool prefix. Exactly one of those two values.
 - `args` — the full arguments object you sent to the tool. Do not rewrite or trim; the server stores these verbatim in `queries[].arguments`.
 - `resultSummary` — optional `{ rows: number, columns: number }` if the tool result has tabular shape you can count. Skip otherwise.
 - `duration_ms` — optional. Skip unless you have a real number.
 - `operationType` — optional. For Socrata, the server auto-derives from `args.type` (`query`, `catalog`, `metadata`, `metrics`); pass through the `args.type` value if you have it. For Data Commons, provide `search` for `search_indicators` and `query` for `get_observations`.
+- `turnIndex` — **multi-turn only**. The `turns[].index` the call belongs to. Used to emit `turn.index` on the `mcp_tool_call` span so future tooling can reconstruct turn grouping from the trace. The server drops this field at the `queries[]` boundary — don't rely on it being surfaced in the package's top-level `queries[]`.
 
 The script synthesizes a minimal OpenTelemetry trace with `mcp_tool_call` spans carrying `mcp.source`, `tool.name`, and `tool.operation_type` — that drives the server's PROV-O graph and `dataSources[]` builder, so **every MCP tool call must be represented here** for attribution to be correct.
 
 ### Optional: skill guidance capture
 
 If the civic-ai-tools repo's skill files are present on disk, you may read them and include the composed text as `skillText` so the published package captures the guidance that shaped the analysis. Use the local copies at `civic-ai-tools/docs/skills/base.md` + `civic-ai-tools/docs/skills/local.md` + `civic-ai-tools/docs/skills/data-commons.md` (concatenate in that order with `\n\n---\n\n` separators). Also set `skillMcpServerUrl` to `"local-stdio (civic-ai-tools/.mcp.json)"` to record that the MCP servers were loaded locally by Claude Code, not fetched over HTTP. This step is optional — omit both fields to publish without a skill-fetch span.
+
+## Large-content handling (blob references)
+
+Per-field inline threshold: **512 KB** (JSON-encoded bytes). The script uploads any field above that to Vercel Blob via the website's `POST /api/blob/upload-token` handshake and references the content by SHA-256 hash. This keeps the POST body under the Next.js ~4 MB cap even for long multi-turn sessions.
+
+Fields that can become a BlobRef: `output`, `trace`, `skillMetadataOverride.skillText`. When `trace` is uploaded as a BlobRef, the server cannot walk spans to extract skill metadata; the script automatically emits `skillMetadataOverride` carrying `systemPromptHash`, `mcpServerUrl`, and `skillText` so those fields land in the package.
+
+The threshold can be overridden with `--max-inline-bytes N` (e.g., force-inline with a very high number for debugging, or force-blob with a low number to exercise the upload path). Don't change it without reason — 512 KB is tuned to keep request bodies comfortably under the cap while avoiding blob overhead for small content.
 
 ## How to invoke the script
 
@@ -76,7 +123,7 @@ If the civic-ai-tools repo's skill files are present on disk, you may read them 
    python3 .claude/skills/publish-evidence/publish.py --payload /tmp/publish-evidence-<timestamp>.json --dry-run
    ```
 
-   This prints a redacted summary — no prompt/output text, no tool args, no session token. Share the summary with the user and ask for go/no-go before publishing.
+   This prints a redacted summary — no prompt/output text, no tool args, no session token — showing `captureMode`, turn count, per-field encoding (inline vs blob), total body bytes, and extension keys. Blob uploads are skipped in dry-run; oversize fields exit 2 with an instructive message so you can raise `--max-inline-bytes` or proceed to the live publish. Share the summary with the user and ask for go/no-go.
 
 3. On confirmation, publish for real:
 
@@ -84,7 +131,7 @@ If the civic-ai-tools repo's skill files are present on disk, you may read them 
    python3 .claude/skills/publish-evidence/publish.py --payload /tmp/publish-evidence-<timestamp>.json
    ```
 
-   The script reads `CIVICAITOOLS_SESSION_TOKEN` (or `CIVICAITOOLS_SESSION_TOKEN_OP`) from the environment. Never echo those values. Never pass them on the command line.
+   The script reads `CIVICAITOOLS_SESSION_TOKEN` (or `CIVICAITOOLS_SESSION_TOKEN_OP`) from the environment. Never echo those values. Never pass them on the command line. Oversized fields are uploaded to Vercel Blob before the `/api/evidence` POST; each upload uses the same session cookie.
 
 4. On success the script prints a JSON result with `slug`, `evidenceUrl`, `packageHash`, and `readbackUrl`. Show the user:
    - The full evidence URL (`https://civicaitools.org/evidence/<slug>`)
@@ -96,16 +143,16 @@ If the civic-ai-tools repo's skill files are present on disk, you may read them 
 ## Error handling
 
 - **Exit 1 (auth)** — session cookie is missing, invalid, or expired. Surface the script's stderr to the user verbatim; do not speculate about fixes beyond what the error says.
-- **Exit 2 (payload)** — your payload violated the schema. Read the stderr, fix the field, try the `--dry-run` again. Do not re-POST.
-- **Exit 3 (network/HTTP)** — transient or server-side. Show the error to the user; offer to retry once. Do not retry automatically without asking.
+- **Exit 2 (payload)** — your payload violated the schema (including oversize fields in dry-run). Read the stderr, fix the field, try the `--dry-run` again. Do not re-POST.
+- **Exit 3 (network/HTTP)** — transient or server-side. Applies to both `/api/evidence` and `/api/blob/upload-token` / Vercel Blob uploads. Show the error to the user; offer to retry once. Do not retry automatically without asking.
 - **Exit 4 (unexpected)** — treat as a bug. Preserve the stderr output; don't retry.
 
 ## Privacy / secret hygiene
 
 - Never `cat`, `head`, `tail`, `echo`, or otherwise print `CIVICAITOOLS_SESSION_TOKEN` or the value referenced by `CIVICAITOOLS_SESSION_TOKEN_OP`.
 - Never include the session-token value or an `op://` reference in the JSON payload, in a commit, or in chat output.
-- The payload JSON contains the prompt text and full output — anything the user would see on the published evidence page. Do not paste it into another repo or share it outside the immediate conversation.
-- If the user's prompt text is sensitive and they don't want it public, set `promptVisibility: "hash_only"` (the server hashes it and stores only the hash).
+- The payload JSON contains the prompt text and full output (or transcript) — anything the user would see on the published evidence page. Do not paste it into another repo or share it outside the immediate conversation.
+- If any part of the captured content is sensitive and the user wants to omit their prompt text from the public record, set `promptVisibility: "hash_only"` (the server hashes it and stores only the hash). There is no equivalent for the transcript — if any transcript turn should not be public, switch back to `single_final_turn` or omit that content before composing the transcript.
 
 ## Long-term cleanup
 

--- a/.claude/skills/publish-evidence/publish.py
+++ b/.claude/skills/publish-evidence/publish.py
@@ -12,6 +12,21 @@ to call; see ``SKILL.md`` next to this file for usage context, or
 ``civic-ai-tools-website/docs/api/evidence-publish.md`` for the endpoint
 contract.
 
+Capture modes:
+
+    single_final_turn   (default) Captures the last user prompt + final
+                        assistant response + tool calls used in that
+                        turn. Matches the website chat flow shape.
+    full_conversation   Captures every captured turn since the civic
+                        analysis started, renders a markdown transcript
+                        as `output`, and emits an
+                        ``extensions["org.civicaitools.multi-turn"]``
+                        block carrying structured turn data for richer
+                        future UI rendering. Large fields above the
+                        inline-bytes threshold are uploaded to Vercel
+                        Blob and referenced by content hash so the
+                        request body stays under the Next.js ~4 MB cap.
+
 Environment variables (read at run time, never logged):
 
     CIVICAITOOLS_SESSION_TOKEN      NextAuth session-token cookie value.
@@ -20,7 +35,7 @@ Environment variables (read at run time, never logged):
                                     ``CIVICAITOOLS_SESSION_TOKEN`` is
                                     unset.
     CIVICAITOOLS_BASE_URL           Override the publish base URL
-                                    (default ``https://civicaitools.org``).
+                                    (default ``https://www.civicaitools.org``).
 
 Exit codes:
 
@@ -49,6 +64,22 @@ DEV_COOKIE_NAME = "next-auth.session-token"
 
 ALLOWED_SOURCES = {"socrata", "data-commons"}
 ALLOWED_PROMPT_VISIBILITY = {"full_text", "hash_only"}
+ALLOWED_CAPTURE_MODES = {"single_final_turn", "full_conversation"}
+ALLOWED_TURN_ROLES = {"user", "assistant", "tool"}
+
+# Per-field size threshold at which content is uploaded to Vercel Blob
+# rather than inlined in the POST /api/evidence body. Chosen to leave
+# comfortable headroom under the Next.js App Router ~4 MB body cap even
+# when several fields land near threshold, while small fields stay
+# inline so verifiers don't need to fetch them separately. Tune via
+# `--max-inline-bytes` if real-world packages land close to either
+# boundary.
+DEFAULT_MAX_INLINE_BYTES = 512 * 1024
+
+# Vercel Blob API constants (from @vercel/blob/client's wire protocol;
+# see civic-ai-tools-website/node_modules/@vercel/blob/dist/client.js).
+VERCEL_BLOB_API_URL = "https://vercel.com/api/blob"
+VERCEL_BLOB_API_VERSION = "12"
 
 
 def eprint(*args: Any, **kwargs: Any) -> None:
@@ -114,10 +145,15 @@ def attr(key: str, value: str) -> dict[str, Any]:
     return {"key": key, "value": {"stringValue": value}}
 
 
+def int_attr(key: str, value: int) -> dict[str, Any]:
+    return {"key": key, "value": {"intValue": str(value)}}
+
+
 def synthesize_trace(
     tool_calls: list[dict[str, Any]],
     skill_text: str | None,
     skill_mcp_server_url: str | None,
+    turns: list[dict[str, Any]] | None,
 ) -> dict[str, Any]:
     """Build a minimal OpenTelemetry trace from structured tool-call records.
 
@@ -127,6 +163,14 @@ def synthesize_trace(
     ``tool.operation_type``, ``tool.arguments``. Optionally prepends a
     ``skill_fetch`` span so ``skillMetadata`` (including the skill text
     and its hash) lands in the package.
+
+    When ``turns`` is supplied (full_conversation mode), prepends one
+    ``conversation_turn`` span per captured turn carrying ``turn.index``
+    and ``turn.role`` attributes. These spans are additive — every
+    existing walker (data-sources, provenance, skill extraction) filters
+    by explicit span name, so unknown spans are ignored. They exist so
+    future tooling can reconstruct turn boundaries from the trace alone
+    without depending on the extensions block.
     """
     spans: list[dict[str, Any]] = []
 
@@ -140,6 +184,20 @@ def synthesize_trace(
             skill_attrs.append(attr("skill.mcp_server_url", skill_mcp_server_url))
         spans.append({"name": "skill_fetch", "attributes": skill_attrs})
 
+    if turns:
+        for turn in turns:
+            turn_attrs = [
+                int_attr("turn.index", int(turn["index"])),
+                attr("turn.role", turn["role"]),
+            ]
+            spans.append(
+                {
+                    "name": "conversation_turn",
+                    "spanId": f"turn-{int(turn['index']):04d}",
+                    "attributes": turn_attrs,
+                }
+            )
+
     for idx, call in enumerate(tool_calls):
         source = call.get("source", "")
         tool_name = call.get("name", "")
@@ -151,6 +209,13 @@ def synthesize_trace(
             attr("tool.operation_type", operation_type),
             attr("tool.arguments", args_json),
         ]
+        # Record turn membership on the span itself so future tooling can
+        # reconstruct turn grouping without reading extensions. Dropped
+        # at the server's queries[] mapping boundary, so this is purely
+        # a trace-level record.
+        turn_index = call.get("turnIndex")
+        if turn_index is not None:
+            span_attrs.append(int_attr("turn.index", int(turn_index)))
         spans.append(
             {
                 "name": "mcp_tool_call",
@@ -166,6 +231,28 @@ def synthesize_trace(
             }
         ]
     }
+
+
+def _validate_turn(turn: dict[str, Any], idx: int) -> None:
+    if not isinstance(turn, dict):
+        eprint(f"error: turns[{idx}] must be an object")
+        sys.exit(2)
+    for required_key in ("index", "role", "content"):
+        if required_key not in turn:
+            eprint(f"error: turns[{idx}] requires `{required_key}`")
+            sys.exit(2)
+    if turn["role"] not in ALLOWED_TURN_ROLES:
+        eprint(
+            f"error: turns[{idx}].role must be one of "
+            f"{sorted(ALLOWED_TURN_ROLES)} (got {turn['role']!r})"
+        )
+        sys.exit(2)
+    if not isinstance(turn["index"], int):
+        eprint(f"error: turns[{idx}].index must be an integer")
+        sys.exit(2)
+    if not isinstance(turn["content"], str):
+        eprint(f"error: turns[{idx}].content must be a string")
+        sys.exit(2)
 
 
 def validate_payload(payload: dict[str, Any]) -> None:
@@ -202,6 +289,10 @@ def validate_payload(payload: dict[str, Any]) -> None:
         if "args" not in call or not isinstance(call["args"], dict):
             eprint(f"error: toolCalls[{idx}].args must be an object")
             sys.exit(2)
+        if "turnIndex" in call and call["turnIndex"] is not None:
+            if not isinstance(call["turnIndex"], int):
+                eprint(f"error: toolCalls[{idx}].turnIndex must be an integer")
+                sys.exit(2)
     prompt_visibility = payload.get("promptVisibility", "full_text")
     if prompt_visibility not in ALLOWED_PROMPT_VISIBILITY:
         eprint(
@@ -209,15 +300,259 @@ def validate_payload(payload: dict[str, Any]) -> None:
             f"{sorted(ALLOWED_PROMPT_VISIBILITY)} (got {prompt_visibility!r})"
         )
         sys.exit(2)
+    capture_mode = payload.get("captureMode", "single_final_turn")
+    if capture_mode not in ALLOWED_CAPTURE_MODES:
+        eprint(
+            f"error: captureMode must be one of "
+            f"{sorted(ALLOWED_CAPTURE_MODES)} (got {capture_mode!r})"
+        )
+        sys.exit(2)
+    if capture_mode == "full_conversation":
+        turns = payload.get("turns")
+        if not isinstance(turns, list) or len(turns) == 0:
+            eprint(
+                "error: captureMode=full_conversation requires a non-empty "
+                "`turns` list describing the captured conversation turns."
+            )
+            sys.exit(2)
+        for idx, turn in enumerate(turns):
+            _validate_turn(turn, idx)
+        # Enforce consistent ordering so the transcript and the
+        # conversation_turn spans agree on turn identity.
+        indices = [t["index"] for t in turns]
+        if indices != sorted(indices):
+            eprint(
+                "error: turns[].index values must be monotonically increasing "
+                "(the script does not reorder them)."
+            )
+            sys.exit(2)
 
 
-def build_request_body(payload: dict[str, Any]) -> dict[str, Any]:
+def byte_length(value: Any) -> int:
+    """Return the UTF-8 byte length of ``value``.
+
+    Strings hash/upload as their UTF-8 encoding. Non-string values
+    (dict/list) are serialised first with the same ``json.dumps`` shape
+    that would be uploaded so the threshold check matches what actually
+    ends up in the blob.
+    """
+    if isinstance(value, str):
+        return len(value.encode("utf-8"))
+    return len(json.dumps(value).encode("utf-8"))
+
+
+def content_to_bytes(value: Any, content_type: str) -> bytes:
+    """Serialise ``value`` for blob upload.
+
+    Strings go through as UTF-8; structured values (OTel traces) are
+    serialised as JSON. ``content_type`` is informational here — the
+    server accepts the same body regardless — but the caller uses it to
+    decide whether to json.dumps or just encode.
+    """
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    return json.dumps(value).encode("utf-8")
+
+
+def mint_upload_token(
+    base_url: str,
+    pathname: str,
+    session_token: str,
+    cookie_name: str,
+) -> str:
+    """Mint a presigned client token for a single blob upload.
+
+    Wraps the first half of the ``@vercel/blob/client`` upload flow:
+    POST ``/api/blob/upload-token`` with the ``blob.generate-client-token``
+    event, receive a ``vercel_blob_client_...`` token authorised for
+    exactly this pathname.
+    """
+    url = f"{base_url.rstrip('/')}/api/blob/upload-token"
+    body = {
+        "type": "blob.generate-client-token",
+        "payload": {
+            "pathname": pathname,
+            "clientPayload": None,
+            "multipart": False,
+        },
+    }
+    encoded = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=encoded,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Cookie": f"{cookie_name}={session_token}",
+            "User-Agent": "civic-ai-tools-publish-evidence/0.2",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            resp_body = resp.read().decode("utf-8")
+            parsed = json.loads(resp_body)
+            token = parsed.get("clientToken")
+            if not token:
+                eprint(
+                    "error: upload-token response missing `clientToken`: "
+                    f"{resp_body[:300]}"
+                )
+                sys.exit(3)
+            return token
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8")
+        except Exception:
+            detail = ""
+        if exc.code == 401:
+            eprint(
+                "error: 401 Unauthorized from /api/blob/upload-token. The "
+                "session cookie is missing, invalid, or expired. Sign in "
+                "at civicaitools.org, re-copy the cookie, and update "
+                "CIVICAITOOLS_SESSION_TOKEN."
+            )
+            sys.exit(1)
+        eprint(f"error: HTTP {exc.code} from /api/blob/upload-token.")
+        if detail:
+            eprint(f"  response body: {detail[:500]}")
+        sys.exit(3)
+    except urllib.error.URLError as exc:
+        eprint(
+            f"error: network failure minting upload token: {exc.reason}"
+        )
+        sys.exit(3)
+
+
+def put_to_blob_store(
+    pathname: str,
+    content: bytes,
+    content_type: str,
+    client_token: str,
+) -> str:
+    """PUT ``content`` to Vercel Blob using a presigned client token.
+
+    Mirrors the second half of the ``@vercel/blob/client`` upload flow
+    (see ``chunk-WLMB4XQD.js``'s ``requestApi`` + ``createPutHeaders``):
+    PUT ``https://vercel.com/api/blob/?pathname=<p>`` with the
+    Authorization bearer token plus Vercel-specific blob headers. The
+    response is JSON with the public blob URL.
+    """
+    from urllib.parse import urlencode
+
+    query = urlencode({"pathname": pathname})
+    url = f"{VERCEL_BLOB_API_URL}/?{query}"
+    req = urllib.request.Request(
+        url,
+        data=content,
+        method="PUT",
+        headers={
+            "Authorization": f"Bearer {client_token}",
+            "x-api-version": VERCEL_BLOB_API_VERSION,
+            "x-vercel-blob-access": "public",
+            "x-content-type": content_type,
+            "Content-Type": content_type,
+            "User-Agent": "civic-ai-tools-publish-evidence/0.2",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=180) as resp:
+            resp_body = resp.read().decode("utf-8")
+            parsed = json.loads(resp_body)
+            blob_url = parsed.get("url")
+            if not blob_url:
+                eprint(
+                    "error: Vercel Blob PUT response missing `url`: "
+                    f"{resp_body[:300]}"
+                )
+                sys.exit(3)
+            return blob_url
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8")
+        except Exception:
+            detail = ""
+        eprint(
+            f"error: HTTP {exc.code} from Vercel Blob store while uploading "
+            f"{pathname}."
+        )
+        if detail:
+            eprint(f"  response body: {detail[:500]}")
+        sys.exit(3)
+    except urllib.error.URLError as exc:
+        eprint(f"error: network failure uploading blob: {exc.reason}")
+        sys.exit(3)
+
+
+def upload_blob_ref(
+    value: Any,
+    content_type: str,
+    extension: str,
+    base_url: str,
+    session_token: str,
+    cookie_name: str,
+) -> dict[str, Any]:
+    """Upload ``value`` to Vercel Blob and return a BlobRef object.
+
+    Content-addressable: the pathname is derived from the SHA-256 of the
+    uploaded bytes so re-uploads of identical content resolve to the
+    same URL. The returned shape matches the ``BlobRef`` TypeScript
+    interface in the website's ``src/lib/evidence/blob-ref.ts``; the
+    server-side verifier fetches the URL and confirms the hash and size
+    match.
+    """
+    content = content_to_bytes(value, content_type)
+    size = len(content)
+    hash_hex = hashlib.sha256(content).hexdigest()
+    pathname = f"evidence-refs/{hash_hex}{extension}"
+    client_token = mint_upload_token(
+        base_url=base_url,
+        pathname=pathname,
+        session_token=session_token,
+        cookie_name=cookie_name,
+    )
+    blob_url = put_to_blob_store(
+        pathname=pathname,
+        content=content,
+        content_type=content_type,
+        client_token=client_token,
+    )
+    return {
+        "ref": f"blob:sha256:{hash_hex}",
+        "url": blob_url,
+        "contentType": content_type,
+        "size": size,
+    }
+
+
+def build_request_body(
+    payload: dict[str, Any],
+    *,
+    max_inline_bytes: int,
+    blob_upload: Any | None,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Assemble the /api/evidence request body.
+
+    Returns ``(body, stats)``. ``stats`` records per-field size and
+    inline-vs-blob decisions so the dry-run preview can surface them
+    without re-encoding.
+
+    ``blob_upload`` is a callable ``(value, content_type, extension) ->
+    blob_ref`` or ``None``. When ``None``, oversized fields cause an
+    exit — used for dry-run previews that don't have a session cookie.
+    """
     tool_calls = payload["toolCalls"]
+    capture_mode = payload.get("captureMode", "single_final_turn")
+    turns = payload.get("turns") if capture_mode == "full_conversation" else None
+
     trace = synthesize_trace(
         tool_calls=tool_calls,
         skill_text=payload.get("skillText"),
         skill_mcp_server_url=payload.get("skillMcpServerUrl"),
+        turns=turns,
     )
+
     post_tool_calls: list[dict[str, Any]] = []
     for call in tool_calls:
         entry: dict[str, Any] = {
@@ -230,12 +565,61 @@ def build_request_body(payload: dict[str, Any]) -> dict[str, Any]:
             entry["duration_ms"] = call["duration_ms"]
         if "operationType" in call and call["operationType"]:
             entry["operationType"] = call["operationType"]
+        # Intentional: `turnIndex` is not propagated to toolCalls[].
+        # Belt-and-suspenders with the OTel `turn.index` attribute (on
+        # the mcp_tool_call span) + the multi-turn extension block —
+        # both are durable carriers. The server's queries[] mapping
+        # would drop extra fields anyway.
         post_tool_calls.append(entry)
 
+    # Per-field encoding decisions. Each decision is a tuple:
+    #   (value, content_type, extension) -> inline_value_or_blob_ref
+    # The body is assembled from the resolved values; stats records
+    # which path each field took.
+    stats: dict[str, Any] = {"fields": {}}
+
+    def encode_field(
+        field_name: str,
+        value: Any,
+        content_type: str,
+        extension: str,
+    ) -> Any:
+        size = byte_length(value)
+        if size <= max_inline_bytes:
+            stats["fields"][field_name] = {
+                "encoding": "inline",
+                "bytes": size,
+            }
+            return value
+        if blob_upload is None:
+            eprint(
+                f"error: field `{field_name}` is {size:,} bytes which exceeds "
+                f"the {max_inline_bytes:,}-byte inline threshold, but blob "
+                "uploads are disabled (dry-run or --no-blob). Re-run without "
+                "--dry-run (with a valid session cookie) so the field can be "
+                "uploaded to Vercel Blob, or raise --max-inline-bytes."
+            )
+            sys.exit(2)
+        blob_ref = blob_upload(value, content_type, extension)
+        stats["fields"][field_name] = {
+            "encoding": "blob",
+            "bytes": size,
+            "ref": blob_ref["ref"],
+            "url": blob_ref["url"],
+        }
+        return blob_ref
+
+    output_value = encode_field(
+        "output", payload["output"], "text/markdown", ".md"
+    )
+    trace_value = encode_field(
+        "trace", trace, "application/json", ".json"
+    )
+
     body: dict[str, Any] = {
-        "trace": trace,
+        "trace": trace_value,
         "prompt": payload["prompt"],
-        "output": payload["output"],
+        "output": output_value,
         "toolCalls": post_tool_calls,
         "model": payload.get("model", "anthropic/claude-opus-4-7"),
         "portal": payload.get("portal", "n/a"),
@@ -246,9 +630,59 @@ def build_request_body(payload: dict[str, Any]) -> dict[str, Any]:
     }
     if payload.get("duration_ms") is not None:
         body["duration_ms"] = payload["duration_ms"]
-    if payload.get("extensions"):
-        body["extensions"] = payload["extensions"]
-    return body
+
+    # When `trace` is a BlobRef the server can't walk spans to extract
+    # skill metadata. Supply an explicit override so `skillMetadata.*`
+    # isn't blanked out on the package. Field names align with
+    # civic-ai-tools-website/src/lib/evidence/packager.ts#PackageInput
+    # (systemPromptHash — not skillTextHash — matches the `skill.text_hash`
+    # span attribute the packager reads).
+    trace_is_blob = isinstance(trace_value, dict) and "ref" in trace_value
+    skill_text = payload.get("skillText")
+    if trace_is_blob and skill_text:
+        skill_text_value = encode_field(
+            "skillMetadataOverride.skillText",
+            skill_text,
+            "text/markdown",
+            ".md",
+        )
+        override: dict[str, Any] = {
+            "systemPromptHash": hashlib.sha256(
+                skill_text.encode("utf-8")
+            ).hexdigest(),
+            "skillText": skill_text_value,
+        }
+        mcp_server_url = payload.get("skillMcpServerUrl")
+        if mcp_server_url:
+            override["mcpServerUrl"] = mcp_server_url
+        body["skillMetadataOverride"] = override
+
+    # Extensions: start from any caller-supplied block, then layer the
+    # multi-turn extension when applicable. Reverse-DNS keyed so new
+    # extensions can coexist without collision.
+    extensions: dict[str, Any] = {}
+    caller_extensions = payload.get("extensions")
+    if caller_extensions:
+        if not isinstance(caller_extensions, dict):
+            eprint("error: payload.extensions must be an object")
+            sys.exit(2)
+        extensions.update(caller_extensions)
+    if capture_mode == "full_conversation" and turns:
+        extensions["org.civicaitools.multi-turn"] = {
+            "version": "0.1.0",
+            "captureMode": "full_conversation",
+            "sessionBoundary": payload.get(
+                "sessionBoundary", "first_civic_tool_call"
+            ),
+            "turns": turns,
+        }
+    if extensions:
+        body["extensions"] = extensions
+
+    stats["captureMode"] = capture_mode
+    stats["turnCount"] = len(turns) if turns else 0
+    stats["totalBodyBytes"] = byte_length(body)
+    return body, stats
 
 
 def post_evidence(
@@ -266,7 +700,7 @@ def post_evidence(
         headers={
             "Content-Type": "application/json",
             "Cookie": f"{cookie_name}={session_token}",
-            "User-Agent": "civic-ai-tools-publish-evidence/0.1",
+            "User-Agent": "civic-ai-tools-publish-evidence/0.2",
         },
     )
     try:
@@ -312,6 +746,61 @@ def blob_url_for(package_hash: str) -> str:
     return f"https://{VERCEL_BLOB_HOST}/evidence-packages/{package_hash}.json"
 
 
+def _redacted_preview(
+    body: dict[str, Any],
+    payload: dict[str, Any],
+    stats: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a no-sensitive-content summary of the request body."""
+
+    def size_or_ref(value: Any) -> dict[str, Any]:
+        if isinstance(value, dict) and "ref" in value:
+            return {
+                "encoding": "blob",
+                "ref": value["ref"],
+                "url": value["url"],
+                "size": value.get("size"),
+            }
+        return {
+            "encoding": "inline",
+            "chars": len(value) if isinstance(value, str) else byte_length(value),
+        }
+
+    sources = sorted(
+        {c.get("source", "") for c in payload["toolCalls"] if c.get("source")}
+    )
+    ext = body.get("extensions") or {}
+    multi_turn_ext = ext.get("org.civicaitools.multi-turn")
+    preview: dict[str, Any] = {
+        "captureMode": stats.get("captureMode"),
+        "turnCount": stats.get("turnCount"),
+        "title": body["title"],
+        "model": body["model"],
+        "portal": body["portal"],
+        "promptVisibility": body["promptVisibility"],
+        "promptChars": len(body["prompt"]),
+        "output": size_or_ref(body["output"]),
+        "trace": size_or_ref(body["trace"]),
+        "toolCallCount": len(body["toolCalls"]),
+        "sources": sources,
+        "hasSkillText": bool(payload.get("skillText")),
+        "skillMetadataOverride": bool(body.get("skillMetadataOverride")),
+        "tokenUsage": body["tokenUsage"],
+        "duration_ms": body.get("duration_ms"),
+        "extensions": sorted(ext.keys()),
+        "totalBodyBytes": stats.get("totalBodyBytes"),
+    }
+    if multi_turn_ext:
+        preview["multiTurn"] = {
+            "turnCount": len(multi_turn_ext.get("turns", [])),
+            "roles": sorted(
+                {t["role"] for t in multi_turn_ext.get("turns", [])}
+            ),
+            "sessionBoundary": multi_turn_ext.get("sessionBoundary"),
+        }
+    return preview
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Publish a civic-data analysis to civicaitools.org."
@@ -327,7 +816,7 @@ def main() -> None:
         default=os.environ.get("CIVICAITOOLS_BASE_URL", DEFAULT_BASE_URL),
         help=(
             "Override the publish base URL (default: "
-            "$CIVICAITOOLS_BASE_URL or https://civicaitools.org)."
+            "$CIVICAITOOLS_BASE_URL or https://www.civicaitools.org)."
         ),
     )
     parser.add_argument(
@@ -340,7 +829,22 @@ def main() -> None:
         "--dry-run",
         action="store_true",
         help="Build the request body, print a redacted preview, and exit "
-        "without POSTing. Useful for debugging payload shape.",
+        "without POSTing. Blob uploads are skipped; oversize fields exit 2.",
+    )
+    parser.add_argument(
+        "--mode",
+        choices=sorted(ALLOWED_CAPTURE_MODES),
+        default=None,
+        help="Override the payload's `captureMode`. Use "
+        "`single_final_turn` or `full_conversation`.",
+    )
+    parser.add_argument(
+        "--max-inline-bytes",
+        type=int,
+        default=DEFAULT_MAX_INLINE_BYTES,
+        help=f"Per-field inline threshold in bytes (default: "
+        f"{DEFAULT_MAX_INLINE_BYTES}). Fields larger than this are "
+        "uploaded to Vercel Blob and referenced by hash.",
     )
     args = parser.parse_args()
 
@@ -358,31 +862,38 @@ def main() -> None:
         eprint("error: payload root must be a JSON object.")
         sys.exit(2)
 
+    if args.mode:
+        payload["captureMode"] = args.mode
+
     validate_payload(payload)
-    body = build_request_body(payload)
 
     if args.dry_run:
-        preview = {
-            "title": body["title"],
-            "model": body["model"],
-            "portal": body["portal"],
-            "promptVisibility": body["promptVisibility"],
-            "promptChars": len(body["prompt"]),
-            "outputChars": len(body["output"]),
-            "toolCallCount": len(body["toolCalls"]),
-            "sources": sorted(
-                {c.get("source", "") for c in payload["toolCalls"] if c.get("source")}
-            ),
-            "hasSkillText": bool(payload.get("skillText")),
-            "tokenUsage": body["tokenUsage"],
-            "duration_ms": body.get("duration_ms"),
-            "extensions": sorted((body.get("extensions") or {}).keys()),
-        }
-        print(json.dumps(preview, indent=2))
+        body, stats = build_request_body(
+            payload,
+            max_inline_bytes=args.max_inline_bytes,
+            blob_upload=None,
+        )
+        print(json.dumps(_redacted_preview(body, payload, stats), indent=2))
         return
 
     session_token = resolve_session_token()
     cookie_name = DEV_COOKIE_NAME if args.dev else PROD_COOKIE_NAME
+
+    def do_upload(value: Any, content_type: str, extension: str) -> dict[str, Any]:
+        return upload_blob_ref(
+            value=value,
+            content_type=content_type,
+            extension=extension,
+            base_url=args.base_url,
+            session_token=session_token,
+            cookie_name=cookie_name,
+        )
+
+    body, _stats = build_request_body(
+        payload,
+        max_inline_bytes=args.max_inline_bytes,
+        blob_upload=do_upload,
+    )
     # Token value never flows through stdout/stderr from here on.
     result = post_evidence(args.base_url, body, session_token, cookie_name)
 

--- a/docs/publish-evidence.md
+++ b/docs/publish-evidence.md
@@ -48,7 +48,7 @@ Full authentication contract: [`civic-ai-tools-website/docs/api/evidence-publish
 
    The skill auto-triggers on phrases like "publish this as evidence", "publish to civicaitools.org", "sign this analysis", or "make this a verifiable package."
 4. Claude will:
-   - Summarize what it's about to publish (title, summary, token usage, source list).
+   - Summarize what it's about to publish (title, summary, token usage, source list, capture mode).
    - Write the payload to a temp file and run the publish script with `--dry-run` to show a redacted preview.
    - Ask for your go-ahead.
 5. Confirm, and the skill POSTs to `civicaitools.org/api/evidence`. On success it prints:
@@ -57,6 +57,47 @@ Full authentication contract: [`civic-ai-tools-website/docs/api/evidence-publish
    - A readback URL (`/api/evidence/<slug>`) for programmatic inspection
 
 6. Open the URL to run consistency or adversarial attestations from the dashboard.
+
+## Capture modes: single turn vs. full conversation
+
+Claude Code sessions are often multi-turn — exploratory tool use, refinement prompts, mid-session pivots. The skill supports two ways to capture a session:
+
+- **Single final turn (default).** Captures your last question + Claude's final answer + every civic MCP tool call used to produce that answer. Matches the shape of analyses published from the website's chat flow. Say "publish this as evidence" or "sign this answer" to invoke.
+
+- **Full conversation.** Captures every turn since the analysis started and publishes them as a markdown transcript, with structured turn metadata in an `org.civicaitools.multi-turn` extension block. Say "publish this whole session", "publish the full conversation", or "include every turn" to invoke. Large transcripts and traces are automatically uploaded to Vercel Blob and referenced by SHA-256 hash so the POST body stays under the request size cap.
+
+**Session boundary.** In full-conversation mode, capture defaults to starting at the **first Socrata or Data Commons MCP tool call** in the session — Claude Code sessions often include unrelated setup before the civic analysis begins. To include everything from the start of the session (less common, and worth double-checking before you publish), say "publish from the beginning of the session." Claude will confirm before widening the window.
+
+**Prompt field selection.** Claude picks one turn to surface as the analysis `prompt`. By default that's the first captured user message; if the first turn is clearly setup or clarification, Claude promotes the later semantic question ("now compare that to the Bronx") and keeps the earlier context in the transcript.
+
+**Token usage.** Multi-turn publishes sum `promptTokens` + `completionTokens` across every captured turn, not just the final one. The published cost attribution reflects the full analysis workload.
+
+### Example: publishing a multi-turn session
+
+**In Claude Code (Opus 4.7, civic-ai-tools cwd, MCP servers configured):**
+
+> What's the median household income in Manhattan?
+
+Claude searches Data Commons, fetches `Median_Income_Household` for `geoId/36061`, returns an answer.
+
+> Now compare that to the Bronx and Brooklyn.
+
+Claude fetches the same indicator for `geoId/36005` and `geoId/36047`, returns a three-borough comparison.
+
+> And include the margin of error on each figure.
+
+Claude fetches the MoE observations, returns the comparison with ±ranges.
+
+> Publish this whole session as evidence.
+
+The skill:
+- Sets `captureMode: "full_conversation"`, collects all six turns into `turns[]`, tags each civic tool call with its `turnIndex`.
+- Renders `output` as a markdown transcript (`### Turn 1 — User`, `### Turn 1 — Assistant`, etc.).
+- Sums token usage across all turns.
+- Runs `--dry-run` and shows you the redacted preview (turn count, body bytes, whether fields are inline or blob-referenced).
+- On confirmation, POSTs. If the transcript or trace is over 512 KB, they upload to Vercel Blob first; the evidence package ends up with BlobRef entries the detail page resolves server-side.
+
+The published package has `dataSources[]` listing Data Commons, `queries[]` containing every `get_observations` call across all turns, a PROV-O graph reflecting Data Commons provenance, and an `extensions["org.civicaitools.multi-turn"]` block that future UI can surface turn-by-turn.
 
 ## End-to-end example
 
@@ -95,7 +136,13 @@ python3 civic-ai-tools/.claude/skills/publish-evidence/publish.py \
     --dry-run   # optional: preview without POSTing
 ```
 
-The payload schema is documented at the top of `publish.py` and in the `SKILL.md` file alongside it. In short: `title`, `summary`, `prompt`, `output`, `toolCalls[]` with `name` + `source` + `args` per call, and optional `model` / `portal` / `tokenUsage` / `duration_ms` / `extensions` / `skillText` / `skillMcpServerUrl`.
+The payload schema is documented at the top of `publish.py` and in the `SKILL.md` file alongside it. In short: `title`, `summary`, `prompt`, `output`, `toolCalls[]` with `name` + `source` + `args` per call, and optional `captureMode`, `turns[]`, `sessionBoundary`, `model`, `portal`, `tokenUsage`, `duration_ms`, `extensions`, `skillText`, `skillMcpServerUrl`.
+
+CLI flags worth knowing:
+
+- `--mode single_final_turn|full_conversation` — override the payload's `captureMode` without editing the file.
+- `--max-inline-bytes N` — per-field inline threshold (default 524288). Fields above this threshold upload to Vercel Blob via `/api/blob/upload-token` and are referenced by SHA-256 hash in the evidence package.
+- `--dry-run` — validate the payload, print a redacted preview, and exit without POSTing or uploading. Useful for debugging payload shape.
 
 ## Troubleshooting
 
@@ -106,6 +153,8 @@ The payload schema is documented at the top of `publish.py` and in the `SKILL.md
 | `error: ``op`` (1Password CLI) not found` | Using `CIVICAITOOLS_SESSION_TOKEN_OP` without the CLI. | Install with `brew install --cask 1password-cli`, or switch to the plain env var. |
 | Published package shows `operationType: "unknown"` | Tool call was reconstructed without an explicit `operationType`. | Pass `operationType` per tool call (`query`, `search`, `catalog`, `metadata`, `metrics`) in the payload. |
 | PROV-O graph missing a source | A tool call in the analysis didn't end up in `toolCalls[]`. | Walk through the conversation and add the missing call; republish. |
+| `--dry-run` exits 2 with "exceeds the … inline threshold" | A field (usually the transcript in `output`) is larger than 512 KB. | Expected in `--dry-run` — blob uploads are skipped there. Re-run without `--dry-run` and a valid session cookie; the field will upload to Vercel Blob and be referenced by hash. If you need the dry-run to succeed for debugging, raise `--max-inline-bytes`. |
+| Multi-turn package detail page shows only the transcript, not per-turn UI | Expected for now. | Turn-by-turn rendering lives in `extensions["org.civicaitools.multi-turn"]` on the package and is a separate future website ticket. The transcript in `output` still captures every turn verbatim. |
 
 ## Privacy notes
 


### PR DESCRIPTION
## Summary

Closes the Phase B gap identified in #40: the `publish-evidence` Claude Code skill now handles multi-turn sessions, with content-addressable Vercel Blob offload for fields that exceed the Next.js body cap.

- **`captureMode` payload field**, default `single_final_turn` (preserves shipped behavior), with a new `full_conversation` mode for rich Claude Code sessions. Three-layer override stack: payload field (authoritative) → `--mode` CLI flag → natural-language phrasing Claude interprets into the payload field.
- **Structured `turns[]`** with `{index, role, content}`, strict monotonic order, and a `user` / `assistant` / `tool` role enum pinned in SKILL.md.
- **Blob-ref offload** at a per-field 512 KB threshold (tunable via `--max-inline-bytes`). The script mints a presigned token via the existing `POST /api/blob/upload-token` handshake (same NextAuth session cookie as `/api/evidence`), PUTs content directly to Vercel Blob, and emits a `BlobRef` on `output`, `trace`, and/or `skillMetadataOverride.skillText`. When `trace` becomes a BlobRef, the script automatically populates `skillMetadataOverride` (`systemPromptHash`, `mcpServerUrl`, `skillText`) so skill metadata doesn't blank out.
- **OTel trace enrichment** — `conversation_turn` parent spans plus `turn.index` / `turn.role` attributes on the `mcp_tool_call` spans. All additive: every existing walker filters by explicit span name, so unknown spans are ignored.
- **`extensions["org.civicaitools.multi-turn"]`** block carrying the structured turn list, covered by the canonical package hash. Enables future turn-by-turn UI rendering without changing the endpoint contract today.
- **`turnIndex` dropped from `toolCalls[]`** per review feedback — turn grouping lives in OTel `turn.index` span attribute + the multi-turn extension, which are the two durable carriers the server respects.
- SKILL.md documents session-boundary convention (first civic MCP tool call, not session start), multi-turn prompt selection rule, tokenUsage summation rule.

No `civic-ai-tools-website` changes. A richer multi-turn detail-page UI would be a separate future ticket; the transcript-in-`output` already renders on today's UI.

## Test plan

- [x] `publish.py` parses (AST check) and runs both dry-run modes on fixture payloads.
- [x] Dry-run preview surfaces `captureMode`, `turnCount`, per-field encoding (inline/blob), sources, extension keys, total body bytes.
- [x] Edge cases exit 2 with actionable messages: missing `turns[]` in `full_conversation` mode, non-monotonic `turns[].index`, invalid `turns[].role`, oversize field in dry-run.
- [x] `--mode` CLI flag overrides the payload `captureMode`.
- [x] Unit test of the blob-ref path (monkey-patched uploader) confirms `skillMetadataOverride.systemPromptHash` is `sha256(skillText)`, `mcpServerUrl` is preserved, `skillText` is emitted as a BlobRef, and `extensions` carries the multi-turn block.
- [x] Field names verified against `civic-ai-tools-website/src/lib/evidence/packager.ts` (`systemPromptHash`, not `skillTextHash`).
- [x] Blob-upload wire protocol reverse-engineered from `@vercel/blob/client`'s `upload()` and confirmed against the website's upload-token route: `POST /api/blob/upload-token` → returns `clientToken` → `PUT https://vercel.com/api/blob/?pathname=...` with `Authorization: Bearer <clientToken>` + `x-vercel-blob-access: public` + `x-api-version: 12`.
- [ ] **End-to-end live publish** — the one step not validated in this PR's session. Requires a fresh Claude Code session with `civic-ai-tools` as cwd (so the Socrata + Data Commons MCP tools are available) to run a real multi-turn analysis and publish it via `--mode full_conversation`. Recommended before merge: confirm the detail page renders correctly, verify `dataSources[]` + `queries[]` + PROV-O graph + `extensions["org.civicaitools.multi-turn"]` land in the package, and check the `keyTrust` verdict is `active`.

Refs #40.