### PR TITLE
Add roadmap adjuncts, issue template, ADR 0001

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-change.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-change.md
@@ -1,0 +1,50 @@
+---
+name: Roadmap change proposal
+about: Propose a non-trivial change to ROADMAP.md — adding or removing a theme, changing a trust commitment, updating the fork-decision criteria, or similar.
+title: "[Roadmap] "
+labels: ["roadmap-change"]
+---
+
+<!--
+Minor corrections (typos, shipped-status updates, link fixes) can land as direct commits; this template is for non-trivial changes.
+
+Read ROADMAP.md before filing — specifically Sections 2 (vision pillars), 3 (trust commitments), 6 (evidence-system fork), 7 (out of scope), and 8 (governance). Proposals that conflict with the out-of-scope list or the commitment-certainty axis are more likely to be declined.
+-->
+
+## Section of the roadmap
+
+Which section does this change affect?
+
+- [ ] Section 2 — Vision pillars
+- [ ] Section 3 — Trust and reliability commitments
+- [ ] Section 5 — Now / Next / Later
+- [ ] Section 6 — Evidence-system fork
+- [ ] Section 7 — Out of scope
+- [ ] Section 8 — Governance
+- [ ] Other:
+
+## What change is being proposed
+
+Describe the specific change. Concrete replacement text is welcome.
+
+## Outcome framing
+
+What *outcome* does this change serve? Which audience(s) from the `/roadmap` routing strip benefit — government partners, academic or policy partners, OSS contributors, journalists, funders, end users?
+
+## Relationship to the vision pillars
+
+Which pillar(s) does this align with? Are there any it contradicts? (Verifiable by default / Grounded in open civic data / Disclosure not validation / Portable across AI tools / Accessible to non-programmers / Sustainable for solo maintenance / Openly governed.)
+
+## Trust-commitment implications
+
+Does this change create, remove, or modify any of the nine commitments in Section 3? If so, how does it interact with the ≥90-day breaking-change notice?
+
+## Linked issues and context
+
+Issue numbers across the three repos, prior discussions, ADRs.
+
+## Acknowledgement
+
+- [ ] I have read `ROADMAP.md` and the Out-of-scope section in particular.
+- [ ] I understand roadmap changes are reviewed by the maintainer and may require an ADR in `docs/adr/`.
+- [ ] I understand the proposal may be declined if it conflicts with the commitment-certainty axis or out-of-scope list.

--- a/docs/adr/0001-roadmap-governance.md
+++ b/docs/adr/0001-roadmap-governance.md
@@ -1,0 +1,58 @@
+# ADR-0001: Public-roadmap governance
+
+- **Status:** Accepted
+- **Date:** 2026-04-23
+- **Decision-maker:** Solo maintainer
+- **Supersedes:** —
+- **Superseded by:** —
+
+## Context
+
+civic-ai-tools is a multi-repo project (hub `civic-ai-tools`, MCP server `socrata-mcp-server`, website `civic-ai-tools-website`) with six distinct audience types: government partners, academic and policy partners, OSS contributors, journalists, potential funders, and end users. The project is maintained by one person at a one-to-two-week coordinated release cadence; as of v0.8.0 (2026-04-23), it runs three live MCP data sources, a shipped evidence system with external-publish API, and roughly three dozen open issues distributed across the repos.
+
+Three conditions made public-roadmap governance necessary:
+
+1. **Contributor and partner demand.** civic#17 tracked "Project governance: unified roadmap and contribution routing across repos" as an open need from launch.
+2. **The evidence-system fork is unresolved and had not been publicly published *as* unresolved.** The project needs a governance-in-the-open surface for strategic decisions that will not land for months.
+3. **The audience fan-out cannot be served by a single document.** A funder, a journalist, and an OSS contributor need different things from the same project; a monolithic doc dilutes every audience.
+
+## Decision
+
+Adopt `ROADMAP.md` in the hub-repo root with a nine-section structure, refreshed quarterly, featuring:
+
+- Seven vision pillars derived from shipped behavior (Verifiable by default, Grounded in open civic data, Disclosure not validation, Portable across AI tools, Accessible to non-programmers, Sustainable for solo maintenance, Openly governed).
+- Nine trust and reliability commitments, including a five-year operational verifiability window for evidence packages, a one-to-two-week coordinated release cadence, a ≥90-day breaking-change notice on the evidence-package schema and documented publish API, and explicit security triage SLOs.
+- Now / Next / Later horizons on a *commitment-certainty* axis (Now and Next are committed; Later is scoped-not-committed), with each item tagged to pillars and audiences.
+- The evidence-system fork published as an unresolved question, with three observational decision criteria and a public decision deadline of 2026-12-31.
+- An explicit out-of-scope section with nine items.
+- A governance section naming cadence, change process via `.github/ISSUE_TEMPLATE/roadmap-change.md`, a quarterly archive at `docs/roadmap/archive/vYYYY.QN.md`, and audience routing to four adjunct documents.
+
+Supporting artifacts in the same adoption:
+
+- `.github/ISSUE_TEMPLATE/roadmap-change.md` for non-trivial changes.
+- Adjunct stubs under `docs/`: `trust-and-evidence.md`, `research-agenda.md`, `sustainability.md`, `evidence-protocol-fork.md`.
+- This ADR log (`docs/adr/`) to capture future non-obvious decisions.
+- A `/roadmap` page on civicaitools.org mirroring the document with a six-audience routing strip (delivered via the website repo).
+
+## Considered and rejected alternatives
+
+- **No public roadmap.** Rejected: contributor and partner friction; no governance-in-the-open surface for the evidence-system fork; civic#17 would stay open indefinitely.
+- **GitHub Projects board across repos as the primary surface.** Rejected: Projects boards track tasks, not commitments; do not support trust-commitment framing or fork narrative; are not read by non-technical audiences.
+- **Monolithic single-document roadmap addressing all six audiences inline.** Rejected: the document becomes unwieldy and dilutes every audience. The adjunct-routing pattern preserves length discipline.
+- **Calendar-quarter Gantt-style delivery dates on feature items.** Rejected: solo-maintainer capacity makes fixed future dates unreliable. The commitment-certainty axis preserves honesty.
+- **Resolving the evidence-system fork for the roadmap launch.** Rejected: publishing both paths as live is itself the governance-in-the-open move. Forcing resolution would optimize for funder legibility over integrity.
+
+## Consequences
+
+- **Quarterly maintenance cost.** The maintainer commits to a quarterly refresh and archive snapshot.
+- **Change-proposal surface.** Non-trivial roadmap changes now route through a public issue template; some will require an ADR. This slows change velocity slightly and increases legibility.
+- **Public deadline on the evidence-system fork.** A decision is committed for 2026-12-31. Not deciding is no longer cost-free.
+- **Publicly committed breaking-change discipline.** The ≥90-day notice on the evidence-package format and documented publish API is now a commitment, not an informal practice.
+- **Future ADR usage.** This ADR sets the numbering (0001) and shape. Expected future ADRs: the skill-routing-architecture choice from Section 5 Next; the evidence-system fork resolution itself; any identity-model direction changes.
+
+## References
+
+- `ROADMAP.md` (canonical public roadmap).
+- civic#17 — umbrella governance issue closed by the roadmap's merge.
+- `docs/evidence-protocol-fork.md` — long-form fork analysis.
+- `civic-ai-tools-website/docs/design-principles.md` — companion UX + data-model principles (cited by number rather than re-derived).

--- a/docs/evidence-protocol-fork.md
+++ b/docs/evidence-protocol-fork.md
@@ -1,0 +1,51 @@
+# Evidence-protocol fork: long-form analysis
+
+**Audience.** Contributors, collaborators, and readers who want the context behind Section 6 of `ROADMAP.md`.
+**Status.** Living. Public-facing supersession of the maintainer's internal spin-out notes.
+
+## Context
+
+The evidence system that shipped in v0.6.0 is the most reusable piece of infrastructure this project has produced. Its primitives — canonical-JSON signing, Ed25519ph signatures, RFC 3161 timestamping via FreeTSA, Sigstore Rekor publishing, W3C PROV-O provenance graphs, content-addressable packages, a trust registry for key rotation, and an extensions architecture — are not civic-specific. Any AI-assisted analysis that needs tamper-evident provenance could use them: biomedical research, financial analysis, journalism, open science generally.
+
+Two futures are currently reachable. This document describes them at enough depth to support the three decision criteria and the 2026-12-31 resolution date from `ROADMAP.md` Section 6.
+
+## Path A — Civic-branded
+
+The evidence system stays part of civic-ai-tools. The library lives in `civic-ai-tools-website/src/lib/evidence/`. Growth happens through:
+
+- **Extensions.** Additional reverse-DNS extension types (Agent Receipts interop, BPMN replay, visual artifacts, Croissant ML metadata) widen what kinds of civic analysis the package can record without changing the core.
+- **Partner consumers.** Government instances of the civicaitools.org pattern (e.g., a city running its own registry against its own data portals), forks for adjacent topical domains (climate, transit, housing), and compatible tools that adopt the same package format.
+- **Cross-registry reference, later.** A thin federation protocol could emerge eventually, but only if and when partner registries exist.
+
+Under Path A, the project's identity stays civic-AI tooling that produces signed evidence. Maintenance appetite stays at the current level: solo maintainer, one website, the commitments in `ROADMAP.md` Section 3.
+
+## Path B — Domain-neutral spin-out
+
+The evidence library, the registry protocol, and — depending on the Section 5 Next decision on skill-routing architecture — the meta-orchestrator direction are extracted as standalone infrastructure under a neutral name. The library becomes importable by any consumer (another website, a CLI, a Claude Code hook, an MCP server, a framework author). The registry protocol is documented at a level that lets compatible registries be run by other disciplines' communities.
+
+Under Path B, civic-ai-tools is one *instance* of a more general protocol; civicaitools.org is one registry. Maintenance becomes a commitment to external adopters, which requires either expanded solo capacity or a co-maintainer arrangement.
+
+## Open questions that either path has to address
+
+- **Key management.** On civicaitools.org, one platform Ed25519 key signs everything, with rotation via the trust registry. Under Path B, whose key signs? User-generated? Per-domain? An "unsigned dev mode"? The answer shapes whether the library reads as *civic-AI evidence kit* or as *general-purpose signing library*.
+- **Naming.** A civic-branded name optimizes for mission clarity and narrows scope. A neutral name optimizes for cross-domain adoption. Split-branding causes confusion. This decision is downstream of the fork, not upstream.
+- **Relationship to adjacent emerging protocols.** civic-ai-tools' package format is more complete than several adjacent AI-provenance proposals today, but the field is young. The design commitment is to be composable-with, not competing-against; the extensions architecture is meant to absorb other formats as first-class artifacts.
+- **Two-axis skill composition.** A reference consumer past a single data source will eventually want skill guidance composed on two axes — source (Socrata, Data Commons, etc.) and methodology (problem framing, descriptive analysis, equity analysis, benchmarking, communication). civic-ai-tools' source-keyed `SKILL_REGISTRY` is one axis; methodology-axis peers exist in the wild. Any spun-out library should anticipate the two-axis shape.
+
+## Decision criteria (mirrors `ROADMAP.md` Section 6)
+
+1. Whether at least one external integration surface beyond civicaitools.org emerges naturally during 2026.
+2. Whether audience feedback from government, academic, and journalism users skews toward civic-specific framing or general-purpose framing.
+3. Whether maintenance capacity can honestly absorb the additional commitment of third-party adopters depending on extracted infrastructure.
+
+The criteria are observational. Resolution is driven by what actually happens in 2026, not by a preferred narrative.
+
+## What lands when the decision resolves
+
+An ADR in `docs/adr/` records, at minimum:
+
+- The chosen path.
+- The observed state of each of the three criteria at the decision point.
+- Naming decisions (if any).
+- Migration implications — under Path B, what moves where; under Path A, the explicit note that no migration happens.
+- A conditional-Later-items update to `ROADMAP.md` Section 5.

--- a/docs/evidence-protocol-fork.md
+++ b/docs/evidence-protocol-fork.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-The evidence system that shipped in v0.6.0 is the most reusable piece of infrastructure this project has produced. Its primitives — canonical-JSON signing, Ed25519ph signatures, RFC 3161 timestamping via FreeTSA, Sigstore Rekor publishing, W3C PROV-O provenance graphs, content-addressable packages, a trust registry for key rotation, and an extensions architecture — are not civic-specific. Any AI-assisted analysis that needs tamper-evident provenance could use them: biomedical research, financial analysis, journalism, open science generally.
+The evidence system that shipped in v0.6.0 is the most reusable piece of infrastructure this project has produced. Its primitives — canonical-JSON signing, Ed25519 signatures, RFC 3161 timestamping via FreeTSA, Sigstore Rekor publishing, W3C PROV-O provenance graphs, content-addressable packages, a trust registry for key rotation, and an extensions architecture — are not civic-specific. Any AI-assisted analysis that needs tamper-evident provenance could use them: biomedical research, financial analysis, journalism, open science generally.
 
 Two futures are currently reachable. This document describes them at enough depth to support the three decision criteria and the 2026-12-31 resolution date from `ROADMAP.md` Section 6.
 

--- a/docs/research-agenda.md
+++ b/docs/research-agenda.md
@@ -1,0 +1,26 @@
+# Research agenda
+
+**Audience.** Researchers in civic technology, AI evaluation, science and technology studies, and information provenance.
+**Status.** Stub. Refined in parallel with project-level research documentation (tracked under civic#22).
+
+civic-ai-tools is an open research artifact as much as it is a working tool. This document names the research questions the project engages, the evaluation resources it generates as a byproduct, and how external researchers can cite, reproduce, or contribute.
+
+## Questions this project engages directly
+
+1. **Skill-guidance drift and efficacy.** How does model behavior change as explicit skill guidance is provided, revised, and version-captured per publish? How do findings from adversarial attestation on one analysis feed back into guidance revisions that improve the next? The evaluation loop (civic#41) is the mechanism.
+2. **Evidence chains as a legibility primitive.** Does surfacing a cryptographic, tamper-evident provenance chain shift how non-technical readers — journalists, government workers, students — interpret AI-generated analyses? The evidence detail-page UX work (Section 5 Now) is the observational surface.
+3. **Cost calibration and quality tiers.** Which model capabilities matter most for civic-data analysis? What correlations exist between model tier and hallucination, partial completion, or caveat-surfacing behavior? Addressed by website#27, website#28, website#29.
+4. **Identity and credibility in AI-evidence systems.** Which identity models best match the trust needs of civic-data readers? The user-signed-evidence direction (website#67, #69, #70) draws on plural-identity thinking; civic#38 tracks the related Plurality chapter 4-1 research.
+5. **Skill-composition architecture at multi-source scale.** Which architectural shape — dynamic routing, per-tool descriptions, meta-orchestrator MCP, methodology-by-source composition — scales best as the number of civic data sources grows? See Section 5 Next and `docs/research/skill-routing-architectural-shapes.md`.
+
+## Resources generated as byproducts
+
+- **The `guidance-quality` corpus.** Issues labeled `guidance-quality` across the three repos name specific failure modes observed in production, with reproducing queries and commit SHAs. Intended as a longitudinal evaluation corpus for prompt and skill-guidance research.
+- **Published evidence packages.** Each is a public, cryptographically signed record of a model + skill + data combination, with a full trace. Cite by slug or package hash; reproduce by re-running the recorded tool calls against the named source(s).
+- **Landscape analysis.** `docs/research/landscape-analysis.md` surveys comparable civic, evidence, and agent projects. Cross-referenced with `census-mcp-landscape.md`, `skill-routing-architectural-shapes.md`, and `agent-receipts-evaluation.md`.
+
+## Engagement paths
+
+- **Cite.** Reference a specific package by slug or by content hash. Package JSON is canonical; it does not change.
+- **Contribute a `guidance-quality` finding.** Include the query, observed behavior, expected behavior, and the reproducing commit SHAs across relevant repos.
+- **Propose a collaboration.** Open an issue in the hub repo. The project welcomes co-authored evaluations, formal research partnerships, and external replication of its evaluation methodology, within the out-of-scope constraints named in `ROADMAP.md` Section 7.

--- a/docs/sustainability.md
+++ b/docs/sustainability.md
@@ -1,0 +1,40 @@
+# Sustainability
+
+**Audience.** Foundations, civic-tech grant programs, and individual supporters considering support for civic-ai-tools.
+**Status.** Stub. Refined if and when a named funding arrangement lands.
+
+## Current state
+
+civic-ai-tools is a solo-maintained, self-funded, open-source project. All three repositories are MIT-licensed. The demo website runs on Vercel Pro; the Socrata MCP server runs on Render's paid tier; storage is Neon Postgres plus Vercel Blob. Costs are personal; maintainer time is uncompensated.
+
+Release cadence has held at one-to-two-week coordinated cross-repo tags since v0.1.0 (March 2026). The evidence system shipped at v0.6.0, multi-source data access shipped at v0.7.0 and v0.8.0. `ROADMAP.md` is refreshed quarterly.
+
+## Committed regardless of funding
+
+The nine trust and reliability commitments in `ROADMAP.md` Section 3 are the floor. They do not depend on grants, partners, or future contracts. That includes:
+
+- Five-year operational verifiability of every evidence package published since v0.6.0.
+- ≥90-day breaking-change notice on the evidence-package schema and the documented publish API.
+- Security triage SLOs: five business days to acknowledge, thirty days to fix or publicly advise on a critical issue.
+- Publicly disclosed maintenance state if capacity ever changes. No stealth deprecation.
+- A one-to-two-week coordinated release cadence, or an explicit update to `ROADMAP.md` if the cadence changes.
+
+## What directed funding would enable
+
+Without adopting commitments that would require a team, funding could accelerate:
+
+- **Evaluation program depth.** Running the adversarial-attestation eval loop (civic#41) at regular cadence, producing public findings and skill-guidance revisions per round. Reviewer time is the bottleneck.
+- **Data-source coverage.** Adding civic MCP sources beyond the current three (Socrata, Google Data Commons, Boston OpenContext). Portal-registry curation for ArcGIS and other long-tail catalogs.
+- **Accessibility and documentation.** Documentation refresh for non-technical audiences; video walkthroughs; translated surfaces contingent on community capacity (see `ROADMAP.md` Section 7).
+- **Infrastructure.** Migration from single-maintainer hosted services to more durable arrangements as traffic or partner commitments grow.
+
+## What funding would not change
+
+- The MIT license on all three repositories.
+- The *disclosure, not validation* stance in the evidence system.
+- The public, issue-linked roadmap and the ADR process.
+- The out-of-scope list in `ROADMAP.md` Section 7 — including no proprietary data sources, no platform-issued correctness claims, no enterprise SLAs, and no editorial moderation at scale.
+
+## Accountability
+
+Funded work lands under the same Now/Next/Later structure in `ROADMAP.md`, with the funding relationship disclosed on the affected items. Outputs of funded work remain open-source and open-access. A quarterly refresh surfaces what was funded, what shipped, and what slipped.

--- a/docs/trust-and-evidence.md
+++ b/docs/trust-and-evidence.md
@@ -1,0 +1,35 @@
+# Trust and evidence
+
+**Audience.** Government partners, journalists, data editors — any reader who needs to know what an evidence package on civicaitools.org actually claims, and what it does not.
+**Status.** Stub. Refined alongside Section 3 of `ROADMAP.md`.
+
+## What "verifiable" means here
+
+An evidence package published on civicaitools.org is a content-addressable, cryptographically signed record of a single civic-data analysis. "Verifiable" has a specific, narrow meaning: with the package alone and a standard verification tool, anyone can confirm that the package has not been altered since publication, that it was signed by a key listed in the published trust registry, that an independent public timestamp authority saw it at the claimed time, and that an independent transparency log (Sigstore Rekor) recorded the signature.
+
+None of those checks require trusting civicaitools.org. If the site goes offline, a reader with a copy of the package can still verify it end-to-end.
+
+## What is being disclosed
+
+Every package carries its audit trail: which AI model ran the analysis, which MCP data sources it queried, every tool call with its arguments and result summary, the skill-guidance text the model was operating under, and a W3C PROV-O graph naming each agent and data source. "Where did this number come from?" is answerable down to the tool call, not just the data source.
+
+## What is not being claimed
+
+An evidence package proves *provenance*, not *correctness*. "Unverified" on a detail page means no attestation has been added yet — not that the AI got the answer wrong. Correctness review is a separate, separately-signed attestation (`consistency`, `evaluation`, or `expert_attestation`) contributed by an identifiable reviewer. The platform itself does not issue correctness claims. See `civic-ai-tools-website/docs/design-principles.md` for the full *disclosure, not validation* stance.
+
+## How to verify a package
+
+- **Signature.** Ed25519 over canonical-JSON, verifiable against the `kid` entry in `https://www.civicaitools.org/.well-known/evidence-public-keys.json`.
+- **Timestamp.** RFC 3161 token from FreeTSA, verifiable against FreeTSA's published CA chain.
+- **Transparency.** Sigstore Rekor entry, resolvable at `rekor.sigstore.dev`.
+- **Content-addressing.** The package SHA-256 is in the URL slug; mismatched content cannot round-trip.
+
+Long-form verification guidance and the 90-day breaking-change notice on this contract live in `civic-ai-tools-website/docs/api/evidence-publish.md`.
+
+## Withdrawal, not deletion
+
+An author can withdraw a package (a signed, public action with a stated reason). Withdrawal does not erase — it appends a signed lifecycle event that renders on the detail page. A permanent record that a civic-data claim was made and later retracted is more honest than silent deletion. Reinstatement works the same way.
+
+## Key rotation
+
+Signing keys rotate per the runbook at `civic-ai-tools-website/docs/key-rotation.md`. Older keys stay in the trust registry indefinitely; packages signed under a retired key remain verifiable.


### PR DESCRIPTION
## Summary

Supports `ROADMAP.md` (v0.8.0) with the audience-routed adjunct documents and governance scaffolding promised in Sections 6 and 8 of the roadmap.

### Files added

- `docs/trust-and-evidence.md` — verification mechanics, the disclosure-vs-validation stance, withdrawal semantics, key-rotation note. *Audience: government partners, journalists.*
- `docs/research-agenda.md` — open research questions this project engages, the `guidance-quality` corpus as a longitudinal evaluation resource, engagement paths for external researchers. *Audience: academic and policy partners.*
- `docs/sustainability.md` — current self-funded state, what holds without funding, what directed funding could accelerate, what it would not change, accountability. *Audience: funders.*
- `docs/evidence-protocol-fork.md` — long-form Path A / Path B analysis with the open questions the fork has to address (key management, naming, relationship to adjacent protocols, two-axis skill composition). *Audience: contributors and collaborators.*
- `.github/ISSUE_TEMPLATE/roadmap-change.md` — form template for non-trivial roadmap changes. Routes proposers through pillar fit, trust-commitment implications, and out-of-scope checks.
- `docs/adr/0001-roadmap-governance.md` — first ADR. Records the decision to adopt the nine-section roadmap structure, the considered-and-rejected alternatives, and consequences. Establishes the ADR log format for future structural decisions (the skill-routing-architecture choice from Section 5 Next, the evidence-system fork resolution, any identity-model direction changes).

## Stub scoping

Each adjunct is a stub in the sense Section 8 of `ROADMAP.md` anticipates — each will be fleshed out when downstream work produces material to expand it (Section 5 Now items for trust-and-evidence, evaluation-program rounds for research-agenda, any named funding arrangement for sustainability, actual progress on the three decision criteria for evidence-protocol-fork).

## Review status

Do **not merge yet** — planning-chat review expected. Expecting feedback on:

- Stub length and scope (adjuncts range from ~400 to ~700 words; planning chat may prefer tighter)
- Audience phrasing in the trust-and-evidence doc (any government/journalism terminology that needs scrubbing)
- ADR-0001 considered-and-rejected list (any alternatives that should be added or dropped)
- Issue-template shape (MD vs YAML form; number and naming of the pillar/audience checklists)

Structure-only proposal for the `/roadmap` page on civicaitools.org is queued as a separate chat message (not a website-repo PR) per the Step 3 scope.

## Pre-merge checklist

- [ ] Planning-chat review on adjunct-stub scope and wording
- [ ] Planning-chat review on ADR-0001 decision record
- [ ] Planning-chat review on roadmap-change issue template fields
- [ ] Confirm `docs/adr/` naming convention (`NNNN-kebab-name.md`) is the one to keep

## Test plan

- [ ] Read each file in GitHub preview to confirm markdown rendering
- [ ] Confirm the roadmap-change issue template renders as an issue form in the *New issue* dropdown
- [ ] Confirm the ADR's internal links (`ROADMAP.md`, `civic-ai-tools-website/docs/design-principles.md`, `docs/evidence-protocol-fork.md`) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)