### PR TITLE
feat(skill): JSONL readback + negative-pattern gate for publish-evidence

### DIFF
--- a/.claude/skills/publish-evidence/SKILL.md
+++ b/.claude/skills/publish-evidence/SKILL.md
@@ -68,39 +68,92 @@ Before posting, confirm these are all true. If any is missing, ask the user befo
 
 3. **A concrete final response exists** (or, in multi-turn mode, a coherent transcript). Publish what was actually said verbatim — partial completions and flagged uncertainties are fine; the attestation flow on civicaitools.org surfaces them.
 
+## Reading the session JSONL (verbatim capture, do not skip)
+
+Per [ADR-0003](../../../docs/adr/0003-evidence-capture-method.md), prose content (`prompt`, `output`, `turns[].content`) and tool args (`toolCalls[].args`) **must be read verbatim from the Claude Code session JSONL**. Do not write Python string literals from in-context memory for any prose field. Paraphrase looks close to verbatim but is not — earlier publishes that paraphrased introduced fabricated bracketed annotations like `[Tool calls: load Socrata MCP tools via ToolSearch...]` and hand-typed token counts that were off by ~14×. The publishing model is set to `claude-code-jsonl-readback`; the dry-run gate (see below) blocks payloads that show signs of paraphrase.
+
+### Locating the session JSONL
+
+The active session is being appended to in real time as you read this. Resolve the file path:
+
+1. **Encoded cwd directory.** Take the current working directory (run `pwd` if uncertain) and replace every `/` with `-`. Example: `/Users/foo/Code/civic-ai-tools` → `-Users-foo-Code-civic-ai-tools`. The session lives under `~/.claude/projects/<encoded-cwd>/`.
+2. **Session file.** The session you are publishing from is the most-recently-modified `.jsonl` in that directory. `ls -t ~/.claude/projects/<encoded-cwd>/*.jsonl | head -1` resolves it. (Each record carries a constant `sessionId`; you can sanity-check by reading the first non-meta record's `sessionId` field and comparing to the filename stem.)
+
+If the analysis happened in a different chat session than the publish (rare), ask the user for the session ID, then read `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` directly.
+
+### Record shape
+
+Each line is one JSON record. Records you care about for capture:
+
+- `type: "user"` — user-typed messages and auto-emitted tool results. The genuine user prompt has `message.content` as a string (or a list with `text` blocks) and **does not** have `isMeta: true`. Tool results have `message.content` as a list of `tool_result` blocks — skip them; tool-call args come from the `tool_use` blocks instead.
+- `type: "assistant"` — assistant invocations, **one record per content block**. All records sharing the same `message.id` belong to the same invocation. Each record's `message.usage` field is identical across the group; first-write-wins for dedup. Content blocks are typed `text`, `tool_use`, or `thinking`.
+- `type: "system"`, `type: "file-history-snapshot"`, `type: "last-prompt"`, `type: "permission-mode"`, `type: "attachment"` — out of scope for this skill; ignore.
+
+Slash-command output (records whose string content starts with `<command-name>` or `<local-command-stdout>`) and any record with `isMeta: true` are noise — exclude them from prose capture.
+
+### Extraction algorithm
+
+For each user-typed message and each assistant invocation in the analysis window:
+
+1. **Group assistant records by `message.id`** in the order they first appear. Within a group, walk content blocks in document order.
+2. **Filter content blocks by type:**
+   - `text` blocks contribute to prose (`turns[].content`, `output`, single-turn assistant response).
+   - `tool_use` blocks contribute to `toolCalls[]` (see below). Their `input` field is the verbatim args dict.
+   - `thinking` blocks are excluded entirely. They have a `signature:` field that must never appear in the package.
+3. **Sum token usage from one record per `message.id`** (first-write-wins, since usage repeats):
+   - `promptTokens` ← `usage.input_tokens + usage.cache_creation_input_tokens + usage.cache_read_input_tokens` summed across unique `msg.id` values.
+   - `completionTokens` ← `usage.output_tokens` summed across unique `msg.id` values.
+   - Cache tokens fold into `promptTokens` per the package convention; do not surface them as a separate field.
+
+A short Python helper that reads the JSONL and emits the parsed-and-deduped structures is the cleanest way to assemble the payload. The builder pattern is fine for that reader and for the `toolCalls[]`/metadata wrapper. **Do not construct `prompt`, `output`, or `turns[].content` from Python string literals you typed in this conversation** — read them out of the JSONL records.
+
 ## Inputs to assemble
 
-You are assembling a JSON payload that you will pass to the bundled `publish.py` script. Gather the following from the conversation context. Ask for any you cannot infer rather than guessing.
+You are assembling a JSON payload that you will pass to the bundled `publish.py` script. Gather the following. Ask for any you cannot infer rather than guessing.
+
+Fields marked **verbatim from JSONL** must be filled by reading the session JSONL records as described above; do not write them from memory.
 
 | Field | How to populate |
 |------|--------|
-| `title` | A short, specific name for the analysis (≤80 chars, shown on the evidence detail page and in the URL slug). Derive from the user's original question. Ask the user to confirm. |
-| `summary` | 2–4 sentences for a non-technical reader. Neutral third-person voice (never "I" or "we"). Describe what was analyzed, what the key finding was, and any caveats or partial results. |
+| `title` | Inherently model-authored (per ADR-0003). A short, specific name for the analysis (≤80 chars, shown on the evidence detail page and in the URL slug). Derive from the user's original question. Ask the user to confirm. |
+| `summary` | Inherently model-authored. 2–4 sentences for a non-technical reader. Neutral third-person voice (never "I" or "we"). Describe what was analyzed, what the key finding was, and any caveats or partial results. |
 | `captureMode` | `"single_final_turn"` (default) or `"full_conversation"`. See "Capture modes" above. |
-| `prompt` | Single-turn: the user's original analysis question, verbatim. Multi-turn: the first user message in the captured window, OR a later semantic analysis question if the first turn is setup/clarification. Never a "publish this" follow-up. |
-| `output` | Single-turn: the assistant's final markdown response verbatim. Multi-turn: a rendered markdown transcript of every captured turn with `### Turn N — User` / `### Turn N — Assistant` headers (matching `turns[].index` and `turns[].role`). Preserve tables, citations, and caveats. |
-| `turns[]` | Required when `captureMode` is `full_conversation`. Array of `{ index, role, content }` objects, strictly increasing `index`. Roles are `user`, `assistant`, or `tool`. See "Turn roles" above. |
+| `captureMethod` | **Always** `"claude-code-jsonl-readback"` for skill-published packages. The server enum also accepts `"chat-flow-stream"` (website chat path) and `"claude-code-self-report"` (legacy paraphrase path, deprecated 2026-04-28); the skill never sets those. |
+| `prompt` | **Verbatim from JSONL.** Single-turn: the genuine user `message.content` from the user record that prompted the analysis, byte-for-byte. Multi-turn: the first genuine user message in the captured window, OR a later semantic analysis question if the first turn is setup/clarification. Never the "publish this" follow-up. Skip records with `isMeta: true` and slash-command output. |
+| `output` | **Verbatim from JSONL.** Single-turn: the final assistant invocation's `text`-typed content blocks, concatenated in document order. Multi-turn: a rendered markdown transcript built from `turns[]` with `### Turn N — User` / `### Turn N — Assistant` headers (`turns[].index`, `turns[].role`). Both shapes preserve tables, citations, and caveats exactly as the model emitted them. |
+| `turns[]` | **Verbatim from JSONL.** Required when `captureMode` is `full_conversation`. Array of `{ index, role, content }` objects, strictly increasing `index`. Roles are `user`, `assistant`, or `tool`. `content` is the concatenated `text`-typed blocks for assistant turns or the user's `message.content` string for user turns — never thinking, never tool_use markup, never paraphrase. See "Turn roles" above. |
 | `sessionBoundary` | Optional, full_conversation only. `"first_civic_tool_call"` (default) or `"session_start"`. Confirm with the user before setting to `session_start`. |
-| `model` | `anthropic/claude-opus-4-7` if you are Claude Opus 4.7 ("Opus 4.7" appears in the session's model identifier). Use the exact model slug from the current session. |
+| `model` | The model slug from the session's assistant records (`message.model`). For Claude Opus 4.7 that's `anthropic/claude-opus-4-7`. Use the exact slug, do not normalize. |
 | `portal` | `data.cityofnewyork.us` if any Socrata tool calls used NYC Open Data; otherwise the portal used; otherwise `n/a` for Data-Commons-only analyses. |
 | `promptVisibility` | `full_text` by default — the prompt goes into the package in the clear. Switch to `hash_only` only if the user explicitly asks to omit their prompt text. |
-| `tokenUsage.promptTokens`, `tokenUsage.completionTokens` | Single-turn: best available estimates for the one turn. Multi-turn: **sum across all captured turns**. If you cannot reasonably estimate, omit the inner fields (send an empty `{}`). |
+| `tokenUsage.promptTokens`, `tokenUsage.completionTokens` | **Verbatim from JSONL.** Sum per the algorithm above. Do not estimate from prose length, conversation context, or rule-of-thumb token-per-character ratios — those have been observed off by an order of magnitude. If the JSONL is unavailable for some reason, omit the inner fields (send an empty `{}`) rather than guess. |
 | `duration_ms` | Rough end-to-end wall-clock in milliseconds (single-turn) or the span of the captured turns (multi-turn). If unknown, omit. |
 | `toolCalls[]` | One entry per civic MCP tool call made in the captured window — see below. |
 
-### `toolCalls[]` reconstruction
+### `toolCalls[]` reconstruction (verbatim from JSONL)
 
-Walk through every tool call in the captured window. For each one, add an entry:
+Walk every assistant `tool_use` content block in the captured window. For each one with a civic MCP `name` (prefix `mcp__socrata__` or `mcp__data-commons__`), add an entry:
 
-- `name` — the underlying MCP tool name. Strip any `mcp__socrata__` / `mcp__data-commons__` prefix (e.g., `mcp__socrata__get_data` → `get_data`, `mcp__data-commons__search_indicators` → `search_indicators`).
-- `source` — `"socrata"` or `"data-commons"` based on the tool prefix. Exactly one of those two values.
-- `args` — the full arguments object you sent to the tool. Do not rewrite or trim; the server stores these verbatim in `queries[].arguments`.
-- `resultSummary` — optional `{ rows: number, columns: number }` if the tool result has tabular shape you can count. Skip otherwise.
+- `name` — the underlying MCP tool name with the prefix stripped (e.g., `mcp__socrata__get_data` → `get_data`, `mcp__data-commons__search_indicators` → `search_indicators`).
+- `source` — `"socrata"` or `"data-commons"` based on the prefix. Exactly one of those two values.
+- `args` — the `tool_use.input` field copied verbatim (a JSON object). Do not rewrite, trim, or reformat; the server stores these in `queries[].arguments`.
+- `resultSummary` — optional `{ rows: number, columns: number }` if the tool result (in the next user record's `tool_result.content`) has tabular shape you can count. Skip otherwise.
 - `duration_ms` — optional. Skip unless you have a real number.
 - `operationType` — optional. For Socrata, the server auto-derives from `args.type` (`query`, `catalog`, `metadata`, `metrics`); pass through the `args.type` value if you have it. For Data Commons, provide `search` for `search_indicators` and `query` for `get_observations`.
 - `turnIndex` — **multi-turn only**. The `turns[].index` the call belongs to. Used to emit `turn.index` on the `mcp_tool_call` span so future tooling can reconstruct turn grouping from the trace. The server drops this field at the `queries[]` boundary — don't rely on it being surfaced in the package's top-level `queries[]`.
 
 The script synthesizes a minimal OpenTelemetry trace with `mcp_tool_call` spans carrying `mcp.source`, `tool.name`, and `tool.operation_type` — that drives the server's PROV-O graph and `dataSources[]` builder, so **every MCP tool call must be represented here** for attribution to be correct.
+
+## Negative pattern scan (dry-run gate)
+
+`publish.py --dry-run` (and the live publish path) runs a negative pattern scan over `prompt`, `output`, and every `turns[].content` looking for markers that only appear when prose was paraphrased from memory rather than read from JSONL:
+
+- `<thinking>` — leaked thinking-block opening tag.
+- `tool_use` (literal substring with the underscore) — leaked tool-use markup.
+- `toolu_[A-Za-z0-9]+` — leaked tool-use ID.
+- `signature:` — leaked thinking-block signature field.
+
+If any pattern matches, the script exits with a clear error pointing to the field and the offending substring. Re-run the JSONL readback for that field — don't try to scrub the markers out of paraphrased prose. The scan is conservative on purpose; false positives are recoverable, false negatives compound the disclosure failure ADR-0003 documents.
 
 ### Optional: skill guidance capture
 

--- a/.claude/skills/publish-evidence/publish.py
+++ b/.claude/skills/publish-evidence/publish.py
@@ -60,6 +60,7 @@ import argparse
 import hashlib
 import json
 import os
+import re
 import stat
 import subprocess
 import sys
@@ -80,6 +81,32 @@ ALLOWED_SOURCES = {"socrata", "data-commons"}
 ALLOWED_PROMPT_VISIBILITY = {"full_text", "hash_only"}
 ALLOWED_CAPTURE_MODES = {"single_final_turn", "full_conversation"}
 ALLOWED_TURN_ROLES = {"user", "assistant", "tool"}
+# Capture-method enum per ADR-0003. The skill always emits
+# ``claude-code-jsonl-readback``; the other values exist so the server's
+# wider enum is reachable from the same validator if a payload sets one
+# explicitly. ``claude-code-self-report`` is deprecated for new publishes
+# but retained so legacy packages can be re-rendered with their actual
+# capture method labeled.
+ALLOWED_CAPTURE_METHODS = {
+    "chat-flow-stream",
+    "claude-code-jsonl-readback",
+    "claude-code-self-report",
+}
+DEFAULT_CAPTURE_METHOD = "claude-code-jsonl-readback"
+
+# Negative pattern scan — substrings / regexes that only appear when
+# prose was paraphrased from in-context memory rather than read from the
+# Claude Code session JSONL. Run as a dry-run + live-publish gate.
+# Per ADR-0003 and #60. The bare-string entries are fast substring
+# checks; the regex entry catches tool-use IDs of arbitrary suffix.
+LEAK_LITERAL_PATTERNS: tuple[tuple[str, str], ...] = (
+    ("<thinking>", "leaked <thinking> block opening tag"),
+    ("tool_use", "leaked `tool_use` block markup"),
+    ("signature:", "leaked thinking-block `signature:` field"),
+)
+LEAK_REGEX_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (re.compile(r"toolu_[A-Za-z0-9]+"), "leaked tool-use id (toolu_...)"),
+)
 
 # Per-field size threshold at which content is uploaded to Vercel Blob
 # rather than inlined in the POST /api/evidence body. Chosen to leave
@@ -406,6 +433,86 @@ def _validate_turn(turn: dict[str, Any], idx: int) -> None:
         sys.exit(2)
 
 
+def _scan_for_leaks(field_label: str, value: str) -> list[tuple[str, str]]:
+    """Return ``[(pattern_label, snippet), ...]`` for every leak match in
+    ``value``. ``value`` is the prose content of a single field. The
+    snippet is a small window around the first occurrence, suitable for
+    embedding in an error message without dumping the whole field."""
+    if not isinstance(value, str) or not value:
+        return []
+    findings: list[tuple[str, str]] = []
+    for needle, label in LEAK_LITERAL_PATTERNS:
+        idx = value.find(needle)
+        if idx >= 0:
+            start = max(0, idx - 24)
+            end = min(len(value), idx + len(needle) + 24)
+            snippet = value[start:end].replace("\n", " ")
+            findings.append((label, f"...{snippet}..."))
+    for pattern, label in LEAK_REGEX_PATTERNS:
+        match = pattern.search(value)
+        if match:
+            start = max(0, match.start() - 24)
+            end = min(len(value), match.end() + 24)
+            snippet = value[start:end].replace("\n", " ")
+            findings.append((label, f"...{snippet}..."))
+    # Mention each pattern at most once per field, even if it occurs
+    # multiple times — the user only needs to see that the field needs a
+    # re-read, not every offset.
+    seen_labels: set[str] = set()
+    deduped: list[tuple[str, str]] = []
+    for label, snippet in findings:
+        if label in seen_labels:
+            continue
+        seen_labels.add(label)
+        deduped.append((label, snippet))
+    return deduped
+
+
+def negative_pattern_scan(payload: dict[str, Any]) -> None:
+    """Verify prose fields contain no markers indicating paraphrase from
+    memory rather than verbatim JSONL readback. Exits 2 with a clear
+    error if any leak is found. Per ADR-0003 and #60.
+
+    Scans ``prompt``, ``output`` (only when inline-string; BlobRef
+    ``output`` is uploaded after this gate, which is fine — the BlobRef
+    is hash-bound and the bytes were already vetted before upload), and
+    every ``turns[].content``.
+    """
+    fields_to_scan: list[tuple[str, str]] = []
+    prompt = payload.get("prompt")
+    if isinstance(prompt, str):
+        fields_to_scan.append(("prompt", prompt))
+    output = payload.get("output")
+    if isinstance(output, str):
+        fields_to_scan.append(("output", output))
+    turns = payload.get("turns")
+    if isinstance(turns, list):
+        for idx, turn in enumerate(turns):
+            if isinstance(turn, dict) and isinstance(turn.get("content"), str):
+                fields_to_scan.append((f"turns[{idx}].content", turn["content"]))
+
+    all_findings: list[tuple[str, str, str]] = []
+    for field_label, value in fields_to_scan:
+        for leak_label, snippet in _scan_for_leaks(field_label, value):
+            all_findings.append((field_label, leak_label, snippet))
+
+    if not all_findings:
+        return
+
+    eprint(
+        "error: negative pattern scan failed — payload contains markers that "
+        "only appear when prose is paraphrased from memory rather than read "
+        "verbatim from the Claude Code session JSONL (per ADR-0003)."
+    )
+    eprint("Re-read the affected field(s) directly from the session JSONL; do "
+           "not try to scrub the markers out of paraphrased prose.")
+    eprint("")
+    for field_label, leak_label, snippet in all_findings:
+        eprint(f"  - {field_label}: {leak_label}")
+        eprint(f"    near: {snippet}")
+    sys.exit(2)
+
+
 def validate_payload(payload: dict[str, Any]) -> None:
     required = [
         "title",
@@ -456,6 +563,13 @@ def validate_payload(payload: dict[str, Any]) -> None:
         eprint(
             f"error: captureMode must be one of "
             f"{sorted(ALLOWED_CAPTURE_MODES)} (got {capture_mode!r})"
+        )
+        sys.exit(2)
+    capture_method = payload.get("captureMethod", DEFAULT_CAPTURE_METHOD)
+    if capture_method not in ALLOWED_CAPTURE_METHODS:
+        eprint(
+            f"error: captureMethod must be one of "
+            f"{sorted(ALLOWED_CAPTURE_METHODS)} (got {capture_method!r})"
         )
         sys.exit(2)
     if capture_mode == "full_conversation":
@@ -790,6 +904,7 @@ def build_request_body(
         "promptVisibility": payload.get("promptVisibility", "full_text"),
         "title": payload["title"],
         "summary": payload["summary"],
+        "captureMethod": payload.get("captureMethod", DEFAULT_CAPTURE_METHOD),
     }
     if payload.get("duration_ms") is not None:
         body["duration_ms"] = payload["duration_ms"]
@@ -955,6 +1070,7 @@ def _redacted_preview(
     multi_turn_ext = ext.get("org.civicaitools.multi-turn")
     preview: dict[str, Any] = {
         "captureMode": stats.get("captureMode"),
+        "captureMethod": body.get("captureMethod"),
         "turnCount": stats.get("turnCount"),
         "title": body["title"],
         "model": body["model"],
@@ -1250,6 +1366,7 @@ def main() -> None:
         payload["captureMode"] = args.mode
 
     validate_payload(payload)
+    negative_pattern_scan(payload)
 
     if args.dry_run:
         body, stats = build_request_body(

--- a/.claude/skills/publish-evidence/test_publish.py
+++ b/.claude/skills/publish-evidence/test_publish.py
@@ -1,0 +1,67 @@
+"""Minimal tests for publish.py — negative pattern scan + captureMethod
+validation. Run with ``python3 test_publish.py`` (no pytest dependency).
+
+Per civic-ai-tools#60 / ADR-0003. The publishing model's full JSONL-readback
+pipeline is end-to-end-tested by actual publishes; these tests cover only
+the gates that publish.py itself enforces."""
+from __future__ import annotations
+
+import io
+import sys
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import publish  # noqa: E402  (import after sys.path tweak)
+
+
+def _payload(**overrides: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "title": "t",
+        "summary": "s",
+        "prompt": "p",
+        "output": "o",
+        "toolCalls": [],
+    }
+    base.update(overrides)
+    return base
+
+
+class NegativePatternScanTests(unittest.TestCase):
+    def test_clean_payload_passes(self) -> None:
+        publish.negative_pattern_scan(_payload())
+
+    def test_thinking_tag_in_output_fails(self) -> None:
+        with self.assertRaises(SystemExit) as cm, redirect_stderr(io.StringIO()):
+            publish.negative_pattern_scan(_payload(output="hello <thinking> bad"))
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_toolu_id_in_prompt_fails(self) -> None:
+        with self.assertRaises(SystemExit) as cm, redirect_stderr(io.StringIO()):
+            publish.negative_pattern_scan(_payload(prompt="ref toolu_01ABCdef"))
+        self.assertEqual(cm.exception.code, 2)
+
+    def test_signature_in_turn_content_fails(self) -> None:
+        turns = [{"index": 0, "role": "user", "content": "x"},
+                 {"index": 1, "role": "assistant", "content": "signature: foo"}]
+        with self.assertRaises(SystemExit) as cm, redirect_stderr(io.StringIO()):
+            publish.negative_pattern_scan(_payload(turns=turns))
+        self.assertEqual(cm.exception.code, 2)
+
+
+class CaptureMethodValidationTests(unittest.TestCase):
+    def test_default_passes(self) -> None:
+        publish.validate_payload(_payload())
+
+    def test_jsonl_readback_passes(self) -> None:
+        publish.validate_payload(_payload(captureMethod="claude-code-jsonl-readback"))
+
+    def test_unknown_method_fails(self) -> None:
+        with self.assertRaises(SystemExit) as cm, redirect_stderr(io.StringIO()):
+            publish.validate_payload(_payload(captureMethod="made-up"))
+        self.assertEqual(cm.exception.code, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/publish-evidence.md
+++ b/docs/publish-evidence.md
@@ -68,8 +68,9 @@ Full authentication contract: [`civic-ai-tools-website/docs/api/evidence-publish
 
    The skill auto-triggers on phrases like "publish this as evidence", "publish to civicaitools.org", "sign this analysis", or "make this a verifiable package."
 4. Claude will:
-   - Summarize what it's about to publish (title, summary, token usage, source list, capture mode).
-   - Write the payload to a temp file and run the publish script with `--dry-run` to show a redacted preview.
+   - Read the session JSONL at `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` to capture prose content (`prompt`, `output`, `turns[].content`), tool args, and per-invocation token usage verbatim. (See "Verbatim capture from JSONL" below for what this means and why.)
+   - Summarize what it's about to publish (title, summary, token usage, source list, capture mode, capture method).
+   - Write the payload to a temp file and run the publish script with `--dry-run` — which validates schema, runs the negative pattern scan, and prints a redacted preview.
    - Ask for your go-ahead.
 5. Confirm, and the skill POSTs to `civicaitools.org/api/evidence`. On success it prints:
    - The public URL (`https://civicaitools.org/evidence/<slug>`)
@@ -77,6 +78,20 @@ Full authentication contract: [`civic-ai-tools-website/docs/api/evidence-publish
    - A readback URL (`/api/evidence/<slug>`) for programmatic inspection
 
 6. Open the URL to run consistency or adversarial attestations from the dashboard.
+
+## Verbatim capture from JSONL
+
+Per [ADR-0003](./adr/0003-evidence-capture-method.md), packages published from this skill carry `captureMethod: "claude-code-jsonl-readback"` — meaning prose content and tool args are read directly from the Claude Code session log on disk (`~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`), not reconstructed from the publishing model's in-context memory. This matters because:
+
+- The cryptographic signature on the package attests "this content was published and has not been tampered with since," not "this content matches the original session." For chat-flow packages those are the same (the website server captured bytes from the model stream); for skill-published packages they only line up if the skill reads the session log verbatim.
+- Earlier publishes that paraphrased from memory introduced fabricated bracketed annotations (e.g., `[Tool calls: load Socrata MCP tools via ToolSearch...]` that were never emitted in the original session) and hand-typed token counts that have been observed off by ~14× on prompt tokens.
+
+Two safeguards keep the skill on the verbatim path:
+
+1. **JSONL readback in `SKILL.md`.** The skill instructs the publishing model to walk the session JSONL line-by-line, group assistant content blocks by `message.id`, filter to `text`-typed blocks for prose, copy `tool_use.input` verbatim for tool args, and sum `usage.input_tokens + cache_creation_input_tokens + cache_read_input_tokens` and `usage.output_tokens` once per unique `message.id` for token totals.
+2. **Negative pattern scan in `publish.py --dry-run`.** The script scans `prompt`, `output`, and every `turns[].content` for substrings that only appear when prose was paraphrased — `<thinking>` tags, the literal text `tool_use`, `toolu_*` IDs, and `signature:` fields. Any match exits non-zero with the field name and a snippet, so you can re-read that field from the JSONL rather than ship a paraphrased package.
+
+If the dry-run scan flags a field, the fix is to re-read it from the JSONL — not to scrub the markers out of paraphrased prose.
 
 ## Capture modes: single turn vs. full conversation
 
@@ -156,13 +171,15 @@ python3 civic-ai-tools/.claude/skills/publish-evidence/publish.py \
     --dry-run   # optional: preview without POSTing
 ```
 
-The payload schema is documented at the top of `publish.py` and in the `SKILL.md` file alongside it. In short: `title`, `summary`, `prompt`, `output`, `toolCalls[]` with `name` + `source` + `args` per call, and optional `captureMode`, `turns[]`, `sessionBoundary`, `model`, `portal`, `tokenUsage`, `duration_ms`, `extensions`, `skillText`, `skillMcpServerUrl`.
+The payload schema is documented at the top of `publish.py` and in the `SKILL.md` file alongside it. In short: `title`, `summary`, `prompt`, `output`, `toolCalls[]` with `name` + `source` + `args` per call, and optional `captureMode`, `captureMethod`, `turns[]`, `sessionBoundary`, `model`, `portal`, `tokenUsage`, `duration_ms`, `extensions`, `skillText`, `skillMcpServerUrl`. `captureMethod` defaults to `"claude-code-jsonl-readback"` and is the only value the skill should set; the wider enum (`chat-flow-stream`, `claude-code-self-report`) is reachable for completeness only.
+
+When publishing without a Claude conversation in the loop, you are responsible for the JSONL readback yourself — copying prose into `prompt` / `output` / `turns[].content` from a Python string literal you typed will trip the negative pattern scan as soon as the captured session contained any thinking blocks or tool-use IDs.
 
 CLI flags worth knowing:
 
 - `--mode single_final_turn|full_conversation` — override the payload's `captureMode` without editing the file.
 - `--max-inline-bytes N` — per-field inline threshold (default 524288). Fields above this threshold upload to Vercel Blob via `/api/blob/upload-token` and are referenced by SHA-256 hash in the evidence package.
-- `--dry-run` — validate the payload, print a redacted preview, and exit without POSTing or uploading. Useful for debugging payload shape.
+- `--dry-run` — validate the payload, run the negative pattern scan, print a redacted preview, and exit without POSTing or uploading. Useful for debugging payload shape and for catching accidental paraphrase before publication.
 
 ## Troubleshooting
 
@@ -176,6 +193,7 @@ CLI flags worth knowing:
 | Published package shows `operationType: "unknown"` | Tool call was reconstructed without an explicit `operationType`. | Pass `operationType` per tool call (`query`, `search`, `catalog`, `metadata`, `metrics`) in the payload. |
 | PROV-O graph missing a source | A tool call in the analysis didn't end up in `toolCalls[]`. | Walk through the conversation and add the missing call; republish. |
 | `--dry-run` exits 2 with "exceeds the … inline threshold" | A field (usually the transcript in `output`) is larger than 512 KB. | Expected in `--dry-run` — blob uploads are skipped there. Re-run without `--dry-run` and valid credentials; the field will upload to Vercel Blob and be referenced by hash. If you need the dry-run to succeed for debugging, raise `--max-inline-bytes`. |
+| `--dry-run` exits 2 with "negative pattern scan failed" | A prose field (`prompt`, `output`, or a `turns[].content`) contains markers that only appear when the content was paraphrased rather than read from the session JSONL. | Re-read the offending field directly from `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` — group assistant records by `message.id`, filter content blocks to `text` only, and copy verbatim. Don't try to scrub the markers out of paraphrased prose. |
 | Multi-turn package detail page shows only the transcript, not per-turn UI | Expected for now. | Turn-by-turn rendering lives in `extensions["org.civicaitools.multi-turn"]` on the package and is a separate future website ticket. The transcript in `output` still captures every turn verbatim. |
 
 ## Privacy notes


### PR DESCRIPTION
Implements [ADR-0003](docs/adr/0003-evidence-capture-method.md) in the publish-evidence skill. Closes #60.

## Summary

- **SKILL.md** now instructs the publishing model to read prose content (`prompt`, `output`, `turns[].content`) and tool args (`toolCalls[].args`) verbatim from `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, with explicit rules for `msg.id` grouping (assistant invocations span multiple JSONL records, one per content block), `text`-only content-block filtering (excluding `thinking` and `tool_use`), and first-write-wins token-usage summing across unique `msg.id` values (cache tokens fold into `promptTokens`).
- **`captureMethod`** is now a payload field defaulted to `claude-code-jsonl-readback` and validated against the ADR-0003 enum. It propagates into the `/api/evidence` POST body and the redacted `--dry-run` preview. The companion website schema field is tracked at civic-ai-tools-website#95 and may not have shipped yet — the skill declares the value regardless and lets the server's tolerance for unknown fields handle the cross-issue ordering.
- **Negative pattern scan** runs as part of `validate_payload` (i.e., on both `--dry-run` and live publishes). It scans `prompt`, `output`, and every `turns[].content` for `<thinking>` tags, the literal `tool_use` substring, `toolu_*` IDs, and `signature:` fields — markers that only appear when prose was paraphrased rather than read from JSONL. Any match exits 2 with a field-and-snippet error.
- **Tests** (`test_publish.py`, stdlib-only `unittest`) cover both gates; run with `python3 test_publish.py`. 7/7 pass locally.
- **`docs/publish-evidence.md`** picks up a "Verbatim capture from JSONL" section, a `captureMethod` mention in the direct-script-invocation flow, and a troubleshooting row for the new dry-run failure mode.

## Why this matters

Per ADR-0003, the cryptographic signature on a package attests "this content was published and has not been tampered with since," not "this content matches the original session." For website chat-flow packages those collapse into one guarantee because the server captured bytes from the model stream; for Claude-Code-published packages they only line up if the skill reads the session log verbatim. The pre-2026-04-28 SKILL.md guidance produced packages with paraphrased multi-turn transcripts (close in length to verbatim but containing fabricated bracketed annotations like `[Tool calls: load Socrata MCP tools via ToolSearch...]`) and hand-typed token usage observed off by ~14× on prompt tokens.

`ca6cd14499f0` shipped 2026-04-28 with the working pattern; this PR lands it as the official guidance and bakes in a structural gate so the next publishing session can't accidentally fall back to memory-paraphrase.

## Test plan

- [x] `python3 .claude/skills/publish-evidence/test_publish.py` (7 assertions, stdlib unittest)
- [x] `publish.py --dry-run` on a clean payload prints the redacted preview including the new `captureMethod` line
- [x] `publish.py --dry-run` on a payload with leaked `<thinking>` and `toolu_*` markers exits 2 with both field+snippet errors
- [ ] Reviewer: spot-check that SKILL.md's readback algorithm is unambiguous enough that a fresh publishing chat would pick it up without re-deriving the pattern
- [ ] Reviewer: confirm `captureMethod` declaration is forward-compatible with the website's incoming schema field (civic-ai-tools-website#95)

## Out of scope (separate issues)

- `captureMethod` schema field on the website + detail-page UI badge (civic-ai-tools-website#95)
- Multi-turn UI rendering / 2,000-char `output` truncation removal (civic-ai-tools-website#96)
- Bronx package retroactive attestation (#61)

🤖 Generated with [Claude Code](https://claude.com/claude-code)