### PR TITLE
docs(licensing): LICENSING.md + license-audit gap fixes (closes #75)

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,37 @@
+# Licensing
+
+The single cross-repo record of license choices for the civic-ai-tools project (civic-ai-tools#75; DPG Standard Indicator 2 evidence for the planned DPGA submission, civic-ai-tools#73). Per-repo `LICENSE` files are authoritative for code; this document explains what applies where and why.
+
+**Audited:** 2026-06-11, against the live state of all four repos, the published npm packages, and the specification text.
+
+## Code
+
+| Repo | License | Notes |
+|------|---------|-------|
+| [civic-ai-tools](https://github.com/npstorey/civic-ai-tools) (this repo) | MIT ([LICENSE](LICENSE)) | Hub: MCP configs, setup scripts, skill docs, examples, architecture docs |
+| [civic-ai-tools-website](https://github.com/npstorey/civic-ai-tools-website) | MIT (LICENSE) | Reference implementation + civicaitools.org |
+| [socrata-mcp-server](https://github.com/npstorey/socrata-mcp-server) | MIT (LICENSE, **dual copyright**) | Fork of Scott Robbin's original MCP server; his copyright line and `author` field are preserved alongside the fork's (© 2025 Scott Robbin, © 2025 Nathan Storey). Published on npm under MIT |
+| typedstandards (private pre-launch) | MIT (LICENSE) | The public artifact is [`@typedstandards/verify-core`](https://www.npmjs.com/package/@typedstandards/verify-core) on npm — MIT, with LICENSE shipped in the tarball. When the repo (or the typedstandards.org spec home) goes public, licensing for that surface is declared as part of the launch (see `q3-session-briefs.md` brief #3, D1) |
+
+## Specification text
+
+- **Typed Standards Specification** (`docs/architecture/typed-standards-specification.md`) — **CC BY 4.0**, declared in the document itself (front matter + §3, with the full-license link and the canonical citation form in Appendix A). Chosen in the ADR-0012 consolidation.
+- **Typed Standards summary one-pager** (`docs/architecture/typed-standards-summary.md`) — CC BY 4.0, same as the full specification (notice added in this audit).
+- **Frozen historical snapshots** (`open-evidence-standard.md`, `civic-claim-vocabulary-draft-spec.md`) — superseded drafts preserved for cross-reference accuracy in pre-consolidation ADRs. Their content was absorbed into the CC BY 4.0 specification and is covered by the same license; the files themselves are not edited post-freeze, so the notice lives here rather than in-file.
+- **All other documentation** (architecture doctrines, guides, skill docs, READMEs) — covered by each repo's MIT license. Only the specification text carries CC BY 4.0, because it is the artifact meant to be cited, excerpted, and adapted by other standards work.
+
+## Project-produced data
+
+- **MCP server directory** (`data/mcp-servers.json`, rendered to `docs/mcp-servers.md`) and the **curated dataset directory** (`docs/datasets.md`) — **CC0 1.0**. These are small, factual, hand-curated registries; dedicating them to the public domain maximizes reuse and matches how the project wants directories treated (declared in this audit).
+
+## Upstream civic data
+
+Data reached through the MCP servers (Socrata portals, Google Data Commons, Boston OpenContext) is **not relicensed by this project**. Each source portal's own terms govern. Evidence packages that quote query results carry that upstream-sourced content under the source's terms; the project's roadmap §7 explicitly disclaims legal advisory on data-use terms.
+
+## Evidence-package registry content — pending decision
+
+Published evidence packages mix four kinds of content with different ownership: platform-generated envelope metadata (hashes, signatures, provenance graph), the author's prompt and analysis framing, model-generated output, and upstream civic-data excerpts. **No license is asserted over registry content today.** Direction under consideration: CC0 for the platform-generated envelope metadata; author-content licensing chosen at publish time with explicit consent UI — which makes it part of the publish-flow identity/consent work tracked at civic-ai-tools-website#70 rather than a unilateral platform declaration. Until that lands, registry pages carry no license statement and reusers should treat author content as all-rights-reserved by default.
+
+## Maintenance
+
+Update this file when: a repo is added or goes public, an npm package's license changes, the evidence-package content decision lands (#70), or the DPGA submission (#73) requires finer-grained evidence.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ New to some of these terms? Here's a quick reference:
 | **API key** | A password-like string that identifies you when making API requests |
 | **Codespace** | A cloud development environment that runs in your browser — no local setup needed |
 
+## License
+
+Code in this repo is MIT (see [LICENSE](LICENSE)). The Typed Standards Specification text is CC BY 4.0 (declared in the document). Cross-repo license choices — including the fork attribution on socrata-mcp-server and the CC0 dedication on the project's directory data — are documented in [LICENSING.md](LICENSING.md).
+
 ## Disclaimer
 
 This is a personal project and is not affiliated with, endorsed by, or representative of any employer or organization.

--- a/docs/architecture/typed-standards-summary.md
+++ b/docs/architecture/typed-standards-summary.md
@@ -3,6 +3,7 @@ Status: v0.1 Working Draft — open for external review (leave-behind summary)
 Last updated: 2026-05-26
 Maintainer: Nathan Storey (current; see reviewer-orientation document for stewardship and contact details)
 Companion: typed-standards-specification.md (full version)
+License: CC BY 4.0 (same as the full specification)
 ---
 
 # Typed Standards

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -3,6 +3,7 @@
 High-value civic datasets across major Socrata open data portals. This is a hand-curated "greatest hits" list — use the MCP server's `search` tool for datasets not listed here.
 
 Last verified: 2026-03-08
+License: CC0 1.0 — this directory (the curation, descriptions, and field notes) is dedicated to the public domain; see [LICENSING.md](../LICENSING.md). The datasets it points to are governed by their source portals' terms.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "civic-ai-tools",
   "version": "0.5.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "scripts": {
     "validate-directory": "node scripts/validate-directory.mjs",


### PR DESCRIPTION
Closes #75 — the cross-repo license audit, with the closing rationale below serving as the issue's close-out record.

## What the audit found (all verified against files, 2026-06-11)

- **All four repos already carry MIT LICENSE files.** socrata-mcp-server's preserves dual fork copyright (© 2025 Scott Robbin, © 2025 Nathan Storey — Robbin confirmed as original author via the package.json `author` field and the repo's initial commits).
- **The Typed Standards Specification already declares CC BY 4.0 in-document** (front matter + §3 with the full-license link + Appendix A citation form, per ADR-0012).
- **`@typedstandards/verify-core`** ships MIT with LICENSE in the npm tarball (registry-verified at 0.6.1).

## What was missing → fixed here

- **`LICENSING.md`** — the issue's single cross-repo record: code table with fork attribution, spec text licensing (including how the frozen OES/CCV snapshots are covered without editing frozen files), project-produced data, upstream-data non-relicensing, and the pending item below. Serves as DPG Indicator 2 evidence for the #73 DPGA submission.
- **Hub README License section** (this repo had a LICENSE file but never mentioned it).
- **`package.json` `license` fields** here and in civic-ai-tools-website (companion one-line PR there).
- **CC BY 4.0 notice** on the summary one-pager's front matter. (Its `.html` sidecar render is now one metadata line behind; regenerate at the next real content edit rather than churning the render.)
- **CC0 1.0 dedication for the project's directory data** — `data/mcp-servers.json` + the `docs/datasets.md` curation (ratified over ODbL: small factual registries; share-alike adds reuse friction without benefit at this scale). Notice added to the datasets.md header; the machine-read JSON is covered by LICENSING.md rather than a schema-breaking inline field.

## Explicit handoff, not silently dropped

**Evidence-package registry content remains an open licensing decision.** Published packages mix platform-generated envelope metadata, author content, model output, and upstream civic-data excerpts with different ownership; no license is asserted over registry content today, and LICENSING.md says so plainly. The decision is handed to **civic-ai-tools-website#70** (publish-time identity-disclosure/consent UI), where author-content licensing naturally belongs. Until that lands, reusers should treat author content as all-rights-reserved by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
