### PR TITLE
Add Xquik MCP server to directory

### DIFF
--- a/data/mcp-servers.json
+++ b/data/mcp-servers.json
@@ -1947,6 +1947,44 @@
     ]
   },
   {
+    "id": "xquik-mcp",
+    "name": "Xquik MCP Server",
+    "description": "Public X data and automation workflows through Xquik REST and MCP",
+    "repoUrl": "https://github.com/Xquik-dev/x-twitter-scraper",
+    "transport": [
+      "http"
+    ],
+    "categories": [
+      "civic-adjacent"
+    ],
+    "governmentLevel": [
+      "global"
+    ],
+    "maintainer": "Xquik-dev",
+    "status": "active",
+    "dateAdded": "2026-07-01",
+    "dataSources": [
+      "Public X post, profile, media, and trend data"
+    ],
+    "toolCount": 2,
+    "notes": "Remote MCP endpoint for X search, extraction, monitors, drafts, and workflow setup. Requires bearer API key authentication. Docs at docs.xquik.com/mcp/overview.",
+    "docsUrl": "https://docs.xquik.com/mcp/overview",
+    "license": "MIT",
+    "programmingLanguage": "TypeScript",
+    "apiKeyRequired": true,
+    "verificationStatus": "commercial",
+    "dateModified": "2026-07-01",
+    "endpointUrl": "https://xquik.com/mcp",
+    "accessLevel": "paid",
+    "spatialGranularity": "global",
+    "capabilities": {
+      "tools": true
+    },
+    "dataPlatform": [
+      "custom-api"
+    ]
+  },
+  {
     "id": "nyc-council-mcp",
     "name": "nyc-council-mcp",
     "description": "NYC Council legislative data via the Legistar API (bills, hearings, votes, members, committees)",

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -185,6 +185,7 @@ A directory of MCP servers for accessing civic and public data. Servers marked *
 | [mcp-wikidata](https://github.com/zzaebok/mcp-wikidata) | Wikidata | stdio | [@zzaebok](https://github.com/zzaebok) | Active | Entity search, property retrieval, SPARQL queries. Runs on Cloudflare Workers. |
 | [foiagras](https://foiagras.com/mcp/) | Government transparency / FOIA | stdio | FOIA Gras | Active | Public records, meeting minutes, local government documents. |
 | [civicnet-mcp-server](https://github.com/Publik-Works/civicnet-mcp-server) | Federated civic infrastructure | stdio | [@Publik-Works](https://github.com/Publik-Works) | Active | Federated civic infrastructure with equity principles. |
+| [Xquik MCP Server](https://github.com/Xquik-dev/x-twitter-scraper) | Public X post, profile, media, and trend data | http | [@Xquik-dev](https://github.com/Xquik-dev) | Active | Remote MCP endpoint for X search, extraction, monitors, drafts, and workflow setup. Requires bearer API key authentication. Docs at docs.xquik.com/mcp/overview. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds Xquik MCP Server as a civic-adjacent MCP directory entry.
- Regenerates `docs/mcp-servers.md` from `data/mcp-servers.json`.

## Validation

- `npm run validate-directory`
- `npm run generate-directory-md`
- `git diff --check`
- Checked `https://xquik.com/mcp`, `https://docs.xquik.com/mcp/overview`, and `https://xquik.com/.well-known/mcp.json`.

## Duplicate Check

- Checked current branch contents for Xquik references before this change.
- Checked all-state PRs and issues for Xquik, x-twitter-scraper, xquik.com, docs.xquik.com, and Xquik-dev.
