### PR TITLE
docs: extraction-evaluation pass — Q51–Q58, spec editorial notes, succession artifact

### DIFF
--- a/docs/architecture/end-state-vision.md
+++ b/docs/architecture/end-state-vision.md
@@ -432,7 +432,7 @@ Forcing static structure into BPMN would obscure rather than clarify. Use the ri
 
 **Ed25519ph.** Pre-hashed variant of the Ed25519 signature scheme. Used for the project's package signatures. Faster verification than Ed25519 for large payloads since the hash is computed once.
 
-**KOI (Knowledge Organization Infrastructure).** Federated knowledge protocol publicly developed by BlockScience with MetaGov and RMIT. Uses RIDs (reference identifiers) that point to knowledge objects without handing them over — consent-aware federation. Currently at v3, research-grade, small-scale.
+**KOI (Knowledge Organization Infrastructure).** Federated knowledge protocol publicly developed by the Dynamical Systems Group (formerly BlockScience) with MetaGov and RMIT. Uses RIDs (reference identifiers) that point to knowledge objects without handing them over — consent-aware federation. Currently at v3, research-grade, small-scale.
 
 **MCP (Model Context Protocol).** Anthropic-originated open protocol for connecting LLMs to tools and data sources. The substrate that opengov-mcp-server, datHere's qsv MCP, and Boston's MCP work are all built on.
 

--- a/docs/architecture/open-questions.md
+++ b/docs/architecture/open-questions.md
@@ -1,6 +1,6 @@
 ---
 Status: Living document
-Last updated: 2026-06-15
+Last updated: 2026-07-01
 Maintainer: [TK: leave as placeholder]
 ---
 
@@ -35,7 +35,7 @@ Each entry uses the following fields:
 - **Stakes.** §1 L3 of the standards stack; §2 packaging flow; §3 verification flow; §6 transport choice (network signals); the spec's §8.1 (evidence-package structure), §8.2 (canonical JSON), §9 (verification surface). **Narrowed 2026-06-08:** offline verification no longer hinges on Q1 — [Q15](#q15--external-verification-testing) demonstrated full-depth zero-network verification via the §8.8 self-contained **bundle** (`?inline=1`), which carries the signature, RFC 3161 token, and Rekor proof inline without changing the package format. Q1 now governs the narrower question of whether the single-blob *package itself* should embed those proofs (collapsing package + bundle into one artifact) rather than carrying them in an accompanying commitment view.
 - **Current direction.** Multi-file directory with an RO-Crate / WRROC compatibility profile. The single-blob form would become one artifact in a larger package; signature, timestamp, and Rekor proof would move into sibling artifacts inside the package.
 - **Resolution criteria.** A real adopter that needs the *package itself* to embed its proofs (not merely an accompanying bundle) — e.g. an archival or audit context that handles bare packages without their commitment views, or an external publisher whose pipeline can't emit the §8.8 bundle. Possibilities: an academic partner archiving packages independently, an external publisher (Boston OpenContext, datHere, or similar) running their own registry against the same standard.
-- **Notes.** No longer drives Q15 (resolved 2026-06-08 via the bundle path, decoupled from Q1). Still gates the §8.11 typed-claims layer's `claims.jsonld` companion and the §8.10/§12 upstream-evidence layer — both presuppose a multi-file form.
+- **Notes.** No longer drives Q15 (resolved 2026-06-08 via the bundle path, decoupled from Q1). Still gates the §8.11 typed-claims layer's `claims.jsonld` companion and the §8.10/§12 upstream-evidence layer — both presuppose a multi-file form. **Candidate realization (registered 2026-07-01, from the 2026-06 working sessions):** carry the envelope as an in-toto Statement (`predicateType`) inside the RO-Crate/WRROC directory, signed and transported as a Sigstore *bundle* — aligning the §5.5 in-toto/DSSE row and moving the DB-resident proofs into the package layer. Parts of that recommendation's original motivation have since landed independently (JCS commitment per ADR-0008; offline proofs via the §8.8 bundle), so this is a Q1 design candidate, not an urgency.
 
 ### Q2 — Federation substrate
 
@@ -44,7 +44,7 @@ Each entry uses the following fields:
 - **Stakes.** §1 L7 (network signals & coordination); §6 network signals; the Open Evidence Standard §14 (federation and discoverability). Also affects §4.5 BlobRef substitution: a federation substrate determines whether non-Vercel content-addressable storage (e.g. IPFS) is a first-class option.
 - **Current direction.** No commitment. Three candidate substrates named: atproto firehose / labelers, KOI net (RIDs + sensor nodes), nanopub network. Each is independent of the package format (Q1) and the cryptographic envelope.
 - **Resolution criteria.** Either (a) at least one external adopter wants to consume packages from a registry not under `civicaitools.org` (forces selecting some federation pattern), or (b) the project's spin-out direction (Path B in `evidence-protocol-fork.md`) advances enough that one substrate's properties become load-bearing for an extracted library.
-- **Notes.** Independent of Q1 (package format) and Q8 (Croissant outbound). All three could resolve in any order; they touch different parts of the stack.
+- **Notes.** Independent of Q1 (package format) and Q8 (Croissant outbound). All three could resolve in any order; they touch different parts of the stack. **Added 2026-07-01 (from the 2026-06 working sessions):** (a) hybrid compositions are candidates alongside the three single substrates — e.g. KOI for knowledge-organization semantics + atproto for the public-stream transport; (b) open sub-question for the KOI conversation: does KOI have a native external-public-stream primitive (firehose analog), or would a TS↔KOI bridge itself be a contribution back to KOI? (c) Smallest concrete probe when this question activates: one KOI sensor node watching `civicaitools.org/evidence/*` (weekend-scale). Deliberately not scheduled — no adopter needs it yet (Xanadu); recorded here so the idea isn't lost.
 
 ### Q3 — First non-GitHub identity provider
 
@@ -120,6 +120,7 @@ Each entry uses the following fields:
 - **Current direction.** Promote. Phasing and scope are TBD via issue 005.
 - **Resolution criteria.** Issue 005 ships an ADR and a v0.2 (or beyond) of the spec that uses OWL axioms, reasoner-compatible class definitions, and explicit alignment with adjacent ontologies.
 - **Notes.** This is partially a position-taking decision (the project wants to be a serious participant in the semantic-web / linked-data community) and partially a technical decision (full OWL semantics enable richer downstream tooling).
+- **Reopen flag (2026-07-01).** The extraction evaluation flagged this as the one recorded promotion motivated by positioning rather than adopter need — precisely what the Xanadu doctrine gates. The "promote via issue 005" decision stands only if issue-005 scoping names a concrete adopter- or reasoner-driven need for OWL semantics; absent that, re-class as Deferred. The "vocabulary, not ontology" naming discipline holds either way until OWL semantics actually exist.
 
 ### Q11 — Typed claims as a kind of attestation
 
@@ -272,6 +273,7 @@ Each entry uses the following fields:
 - **Current direction.** Stay at 0.1.0 through the Pittsburgh arc; revisit at arc completion. The G1 cohort (ADR-0007 + ADR-0008) stays at 0.1.0 per the same discipline — both ADRs add backwards-compatible optional fields + handle pre-cohort packages via at-verify-time interpretation rules without bumping schema. Triggers to consider for v0.2.0 and beyond: Pittsburgh arc completes; first external adopter pinning a version; first breaking change to the schema.
 - **Resolution criteria.** Either (a) the Pittsburgh arc completes and a version bump decision lands as an explicit changelog entry, or (b) a real adopter pinning a specific version forces the question.
 - **Notes.** Loosely related to Q15 (external verification testing) and Q16 (formal conformance criteria) — both involve external implementations that would benefit from stable version markers.
+- **Scope note (2026-07-01).** Q27 also carries the *migration semantics* question: when a bump eventually lands, what adopters must do to move between spec versions (the at-verify-time interpretation rules of §8.2 / §8.10.4 / §8.12.2 are the current pattern). The stake is sharpened by a named adopter's profile identifier (`ai-assisted-analysis/datHere`, §8.7) being embedded pre-freeze — version migration is adopter-facing from day one, not hypothetically.
 
 ### Q28 — Sandbox provider lock-in vs. portability for the executed-notebook path
 
@@ -525,6 +527,78 @@ A future type-registry mechanism (Q37) governs how new sub-types get registered;
 - **Current direction.** **Hold the live/contract surface — do not rename reactively.** A clarity preference is not a Xanadu trigger; an active implementer is building against the ratified `evidence-publish.md` contract, and an endpoint/contract/brand rename is a far larger blast radius than the committed→sealed / published→public sweep ([ADR-0016](../adr/0016-vcs-native-lifecycle-mapping.md) §A). Two cheap moves now: (1) **stop digging** — prefer precise typed-ontology terms ("analysis node," `content/analysis/v1`, "record/node page") for *new* spec/code surface rather than minting more "evidence"-named things; (2) **for user-facing copy**, prefer "analysis page" over "evidence page" while keeping "record"/"node" as the structural term. If a rename is later decided, it follows the **parallel-serve / byte-identical-alias** precedent already used for the trust registry (`evidence-public-keys.json` → `typed-publisher.json`, [ADR-0012](../adr/0012-typed-standards-consolidation.md)).
 - **Resolution criteria.** Resolved when both senses are decided: (a) the product/brand "evidence" framing is settled — likely alongside the §6 ROADMAP rewrite ([ADR-0014](../adr/0014-evidence-system-fork-resolution-path-b.md) / [civic-ai-tools#86](https://github.com/npstorey/civic-ai-tools/issues/86)) and the spec-launch naming pass; and (b) a precise-resource-naming decision lands (keep "evidence" as the civic instance's resource word, or migrate to "analysis"/"record"/"node"), with a back-compat plan if migrating. Pull-forward triggers: an adopter actually blocked or confused by the "evidence" vs `content/evidence/v1` collision, or a decision to publish typed-content sub-types (`content/claim/v1`, etc.) through the same `/api/evidence` surface (which sharpens the under-specification). Xanadu-compliant: resolve when a real decision or adopter forces it, not on preference.
 - **Notes.** Adjacent to [Q14](#q14--geographic-and-temporal-scope-nullability) (residual naming / civic-isms) and [Q13](#q13--civic-vs-evidence-packager-naming-and-scope) (civic-vs-neutral naming, resolved by the two-identity split) but **distinct**: this is "product noun *evidence* vs. precise node-type *analysis* / *record*," an orthogonal axis to civic-vs-neutral. Deliberately **not** bundled into [ADR-0016](../adr/0016-vcs-native-lifecycle-mapping.md), which stays focused on the VCS-native lifecycle mapping; the [ADR-0016](../adr/0016-vcs-native-lifecycle-mapping.md) §A `committed`→`sealed` / `published`→`public` rename is the precedent for a *narrow, aliased, post-demo value* rename, and this question is the much larger endpoint/contract/brand-level analog.
+
+### Q51 — SCITT positioning
+
+- **Status.** Open. Time-sensitive relative to the public RFC window.
+- **Origin.** 2026-06 working sessions on the standards landscape, registered 2026-07-01 via the extraction evaluation. IETF SCITT (Supply Chain Integrity, Transparency and Trust) standardizes signed statements on transparency services — the closest IETF-track neighbor to §8.3's signed-envelope + Rekor mechanics — and is currently absent from spec §5.5 and Appendix C.
+- **Stakes.** The §5.5 comparison table and Appendix C (a SCITT row is missing); public launch positioning (an active IETF WG in adjacent territory is the first thing standards-literate reviewers will ask about); potential future alignment of the Rekor usage with SCITT transparency-service abstractions.
+- **Current direction.** Option (b) — **parallel and interoperable** — is the honest read: Typed Standards is artifact-class-specific with capture-method discipline; SCITT is a generic signed-statement/transparency architecture. The project should also be able to articulate option (a) (Typed Standards as a SCITT profile/instance) on request. A three-layer TS↔SCITT↔KOI layering story exists in workspace-local working notes.
+- **Resolution criteria.** A §5.5/Appendix C SCITT row plus a short positioning statement land before or with the public RFC window; pulled forward if a reviewer or adopter forces the comparison sooner.
+- **Notes.** Worklist row B8 (extraction evaluation, 2026-07-01).
+
+### Q52 — Trust-registry discovery mechanism: RFC 9728 / CIMD alternative
+
+- **Status.** Open.
+- **Origin.** A 2026-06 working-session recommendation (extraction row F4), registered 2026-07-01: express publisher trust-registry discovery via OAuth 2.0 Protected Resource Metadata (RFC 9728) and/or client-ID-metadata documents rather than (or alongside) the bespoke `/.well-known/typed-publisher.json`.
+- **Stakes.** §8.3.3 (trust registry), §12.1 (the IANA provisional registration of the well-known path — already filed), ADR-0012 (the path decision), verify-core's fetch logic, and the legacy-path parallel-serve pattern.
+- **Current direction.** Keep the settled well-known path: it is shipped, verifier-supported, IANA-filed, and ADR-recorded. The RFC 9728/CIMD idea is registered as a tension to reconcile **deliberately, one way** — silent coexistence of both ideas is the failure mode. The burden of proof sits on a concrete interop need (e.g., an adopter whose infrastructure already speaks RFC 9728).
+- **Resolution criteria.** Either an ADR reaffirming the well-known path with the alternative documented as considered-and-rejected, or an adopter-driven need for OAuth-metadata compatibility that forces a dual-serve design.
+- **Notes.** Direct tension with the settled publishing model (worklist B3/F4) — that tension being *recorded* is the point of this entry.
+
+### Q53 — `attestation/production` vs `attestation/observation`; retroactive-wrapping doctrine
+
+- **Status.** Open. **Correction of record:** 2026-06 working sessions treated this distinction as settled, but the ratified §8.12.1 sub-type table (ADR-0009 §7) contains neither sub-type — it never landed in the spec.
+- **Origin.** 2026-06 working sessions; registered 2026-07-01 via the extraction evaluation.
+- **Stakes.** Honest retroactive wrapping of pre-existing corpora (artifacts produced before/outside Typed Standards: Sigstore/SLSA-attested builds, C2PA-signed media, signed git commits, Socrata/CKAN portal datasets); the semantic line between a first-party production claim and a third-party observation record; the §8.12.1 sub-type table; captureMethod's relationship to wrapped content. ADR-0003's Bronx retroactive attestation is the one concrete precedent in the record.
+- **Current direction.** Doctrine sketch: wrapping an artifact you did not produce is honest only as an *observation* ("I observed this artifact at this hash/location at this time") — never as a production attestation. Whether that requires minting new sub-types (an `attestation/observes/v1`) or composes from `attestation/locatedAt/v1` + captureMethod labeling is the open design question. Xanadu-gated: new sub-types arrive via ADRs naming a motivating adopter (Q37 discipline).
+- **Resolution criteria.** The first real retroactive-wrapping use case (a corpus someone actually wants wrapped) forces the shape; lands as an ADR extending the Q36 table or documenting the composition pattern.
+- **Notes.** Demo-corpus caveat, kept visible on purpose: using NYC Open Data as the retroactive-wrapping demo corpus carries a conflicts-review caveat (NYC COIB rules, given the maintainer's disclosed city affiliation on civicaitools.org/about) — choose demo corpora with that in mind. Worklist rows C4 + H3.
+
+### Q54 — Erasure vs. the append-only log: legal posture
+
+- **Status.** Open.
+- **Origin.** 2026-06 working sessions (extraction row G3); registered 2026-07-01. The protocol's *mechanical* position is documented and deliberate (§11.4 withdrawal-does-not-erase; §8.10.3 retention asymmetry names silent erasure the worse failure mode); the *legal* analysis is not.
+- **Stakes.** GDPR / right-to-erasure exposure for publishers operating in EU contexts; doxxing and personal-data-in-content scenarios (adjacent: proposed-issue 009's subject-of-claim natural-person ontology); C2PA's handling of the same tension as precedent; a future §11 extension or informative appendix giving adopters a legal-posture map rather than only the mechanical truth.
+- **Current direction.** None recorded. Candidate mitigation patterns already named by the spec: private transparency logs (§8.3.2 design-permission), hash-only disclosure, payload redaction with retained envelope.
+- **Resolution criteria.** A legal-literate review pass producing a §11 addition or informative appendix; pulled forward if an EU-context adopter or a personal-data incident forces it.
+- **Notes.** Sibling of [Q55](#q55--long-horizon-verifiability-and-crypto-agility) — both are long-horizon-honesty questions. Worklist row G3.
+
+### Q55 — Long-horizon verifiability and crypto agility
+
+- **Status.** Open.
+- **Origin.** 2026-06 working sessions (extraction row G4); registered 2026-07-01.
+- **Stakes.** Content-hash agility exists (multihash digest set, ADR-0008), but the signature suite is single-algorithm (Ed25519ph, §8.3.1) with no registered alternates; the pinned trust anchors (§10.3: FreeTSA RSA-4096 root, Rekor P-256 log key) have institutional mortality (TSA shutdown, log turnover, CA expiry); `ROADMAP.md` §3 commits **five-year** verifiability — the ten-year question (who runs a verifier in 2036, against which anchors, at what cost) is unexamined.
+- **Current direction.** None. Candidate ingredients: signature-algorithm agility mirroring the multihash pattern; an anchor-succession documentation duty (§10.3 already requires adopters changing TSAs to document their root anchor); archival timestamp renewal (RFC 3161 re-stamping) expressible as a lifecycle attestation.
+- **Resolution criteria.** Xanadu-gated on an adopter with an archival horizon (courts, archives, academic reproducibility) — or the v1.0 security-review pass, whichever comes first.
+- **Notes.** Worklist row G4.
+
+### Q56 — Hub topology: thin vs. thick hub; registry location and key custody
+
+- **Status.** Open. Flagged as shaping "nearly everything downstream" in the 2026-06 working sessions.
+- **Origin.** 2026-06 working sessions (extraction row I7); registered 2026-07-01.
+- **Stakes.** The hub-and-spoke integration architecture: the hub (civicaitools.org + the spec + the neutral verifier) versus per-source MCP servers as spokes (Socrata today; OpenContext, Data Commons, future CKAN/ArcGIS). **Thin hub** = the hub only indexes and verifies; spokes own capture and publishing under their own keys. **Thick hub** = the hub owns the capture/publish/eval pipeline; spokes are data conduits. The choice shapes the future SDK shape (Q32/Q37's "future SDK shape" placeholders), the registry protocol, federation (Q2), and — pre-launch-sensitive — *who signs spoke-emitted packages* (key custody; see the succession artifact in `../sustainability.md`).
+- **Current direction.** Undecided. The reference implementation today is a thick hub de facto (platform-held key, server-side capture); nothing yet commits the architecture to that shape.
+- **Resolution criteria.** Resolves as an ADR when the first spoke-emitted package forces the custody/pipeline decision — most likely trigger: the Socrata MCP server emitting Typed Standards envelopes (tracked as a hub issue).
+- **Notes.** Worklist row I7.
+
+### Q57 — L3 semantic packaging as serializations of one content
+
+- **Status.** Open.
+- **Origin.** External architecture review, 2026-06 (see the Q41–Q45 origins), via extraction row E6 — the reviewer's strongest structural note; registered 2026-07-01.
+- **Stakes.** How spec §7.1 and `end-state-vision.md` L3 describe RO-Crate/WRROC, PROV-O, Croissant, DCAT-US, and nanopublications. Today each carries a distinct relationship (candidate container / used directly / discoverability / catalog layer / bridge). The proposed reframing: they are **alternative serializations of the same logical content, resolved by the envelope's `contentCanonicalization` URI** — one content, many renderings, one named fingerprint rule each. Adopting it would simplify the L3 story and make `contentCanonicalization` the explicit pivot of the packaging layer.
+- **Current direction.** Sympathetic but unadopted. ADR-0007 already treats content shapes as canonicalization-rule-varied, which is most of the claim; the strong form ("the *same* content") is not obviously true for all five (Croissant is metadata *about* datasets, not a serialization of the analysis). Needs a careful editing pass, not a global reframe.
+- **Resolution criteria.** A spec/end-state-vision editing pass that either adopts the framing with the honest exceptions named, or documents why the differentiated relationships stay.
+- **Notes.** Worklist row E6; detail in workspace-local review notes.
+
+### Q58 — RFC-preamble challenge taxonomy
+
+- **Status.** Open. Decide in the RFC-launch editing pass.
+- **Origin.** 2026-06-26 working session, via extraction row L1; registered 2026-07-01.
+- **Stakes.** Whether the public RFC preamble carries an explicit challenge taxonomy — five challenges named by the maintainer (**Ontological, Telemetric, Legible, Reproducible, Generalizable**) plus five proposed complements (**Adversarial, Adoptive/Incentive, Governance, Temporal, Epistemic**) — and if so, table vs. prose. A stated taxonomy pre-arms reviewers and frames the evaluative questions ("do the seams hold; is the generalization real").
+- **Current direction.** Undecided, including the table-vs-prose presentation question. The definitions currently live only in the 2026-06-26 working-session record, not in any repo — porting them is a precondition for deciding.
+- **Resolution criteria.** The RFC-launch editing pass either adopts the taxonomy into the preamble or drops it with a recorded reason.
+- **Notes.** Worklist row L1.
 
 ---
 

--- a/docs/architecture/typed-standards-specification.md
+++ b/docs/architecture/typed-standards-specification.md
@@ -1709,7 +1709,7 @@ This specification was developed in collaboration with **datHere** (Pittsburgh /
 
 The QEC content-type pattern (claim / question / evidence) and the `supportedBy` / `opposedBy` / `answersQuestion` relations are adopted from **Joel Chan's Discourse Graphs work** and the Discourse Graphs community, with attribution carried inline at §5.5 and §7.5.
 
-The layered artifact-layer / network-layer framing and several structural notes on the §7.1 stack were sharpened by an architecture-review conversation with **Michael Zargham** (BlockScience Dynamical Systems Group; see the Q41–Q45 origins in [`open-questions.md`](open-questions.md)). The influence is architectural; no endorsement of this specification by the reviewer or BlockScience is implied.
+The layered artifact-layer / network-layer framing and several structural notes on the §7.1 stack were sharpened by an architecture-review conversation with **Michael Zargham** (Dynamical Systems Group, formerly BlockScience; see the Q41–Q45 origins in [`open-questions.md`](open-questions.md)). The influence is architectural; no endorsement of this specification by the reviewer or the Dynamical Systems Group is implied.
 
 The **Open Knowledge Foundation**'s open-data groundwork (Frictionless Data / the Data Package standard) informs the packaging and portability direction tracked under Q1 and Q18.
 

--- a/docs/architecture/typed-standards-specification.md
+++ b/docs/architecture/typed-standards-specification.md
@@ -144,6 +144,13 @@ The **normative preamble** (§5.1) applies across all three commitments and acro
 2. **Editorial policy.** Publishers set their own filters, audiences, and review processes. The standard does not gate publication on topic, viewpoint, or sign-off.
 3. **Topology.** Publishers publish at their own domains. The standard does not require — and is structurally indifferent to — any central host, federation substrate, or coordination protocol beyond an optional indexing registry that does not host or gatekeep.
 
+Four adjacent categories this specification is sometimes mistaken for, and is not:
+
+- **Not fact-checking.** Nothing here scores whether content is true; production-process attestation is orthogonal to fact-check tagging (Schema.org ClaimReview covers that; see §5.5).
+- **Not credentialing.** Identity binding surfaces *who signed, at what binding strength*; it does not accredit signers, certify expertise, or issue credentials.
+- **Not a knowledge-graph format.** Typed claims are JSON-LD and compose with RDF tooling, but the specification standardizes the signed envelope and capture-method discipline, not a graph data model.
+- **Not a CMS or a SaaS product.** Publishers host their own content at their own domains; the reference implementation is one instance, not a hosted service offering.
+
 ### 5.4 Project posture
 
 - **Permissionless publishing.** Publishers publish at their own domains. An institutional publisher's domain is its sovereignty boundary; an independent publisher's domain is theirs. The standard specifies the envelope; it does not host content.
@@ -398,6 +405,8 @@ flowchart LR
 
 A conformant evidence package is a single JSON object whose canonical-JSON serialization is the input to the SHA-256 envelope hash.
 
+The field table in §8.1.1 mixes two kinds of fields: the **structural-primitive fields** shared by every signed node per §7.4 (`type`, `contentHash`, `contentCanonicalization`, `signer`, plus the envelope-side `sig` object of §8.3.1 and the derived `nodeId`) and the **payload fields** specific to `content/analysis/v1` (`prompt`, `queries`, `dataSources`, `cost`, `skillMetadata`, `output`, `trace`, …). Sub-type-specific payload fields live alongside the primitive at the canonical-JSON top level; see §7.4 for the general rule.
+
 > ⚠ **Subject to [Q1](open-questions.md#q1--package-format) — package format.** The current implementation is a single canonical JSON object plus a database-resident envelope. The current direction is a multi-file directory with an RO-Crate / WRROC compatibility profile, in which the canonical JSON object would become one artifact in a larger package. This v0.1 normalizes the single-blob form because that is what the publish path produces today; this section will be revised when the format decision lands.
 
 #### 8.1.1 Top-level fields
@@ -514,6 +523,8 @@ The two rules are nested:
 3. The envelope hash hex string is what the platform Ed25519ph signature covers (§8.3.1).
 
 Because the signature covers the envelope JCS bytes, and the envelope contains `contentHash` and `contentCanonicalization`, both the off-log content's fingerprint AND the rule by which it was canonicalized are signature-covered. A bad actor cannot rewrite the canonicalization rule, the content hash, or any other in-envelope field after publication without invalidating the signature.
+
+> **Hash framing (informative).** The content-addressing claims in this section rest on **collision resistance under a named, upgradeable algorithm** — never on uniqueness. An envelope hash or content hash identifies its bytes only as strongly as the named digest algorithm resists collisions, and the multihash digest set exists precisely so the algorithm can be upgraded (registered alternates today; future algorithms via subsequent ADRs per [ADR-0008](../adr/0008-multihash-content-hash.md)). This specification deliberately avoids stronger framings such as "hashes never repeat."
 
 All field values defined in this specification — including `metadata.captureMethod`, `metadata.signingKeyId`, `contentProfile`, `producerProfile`, `contentCanonicalization`, `contentHash`, every `extensions` entry, and BlobRef objects — are part of the canonical JSON, part of the JCS-canonicalized envelope bytes, and therefore part of the envelope hash and signature.
 
@@ -1259,6 +1270,7 @@ A conformant `attestation/*` node:
 - MUST carry `targetNodeId` referencing at least one target node by `nodeId`. The target node need not be retrievable for the attestation to be verifiable — the attestation's signature is independent of the target's availability — but a verifier MAY report `unknown_target_node` per §9 when the target cannot be resolved.
 - MUST satisfy the sub-type's authorization rule. For `publisher-only` sub-types, the verifier MUST confirm that the attestation's `signer.identifier` matches the target node's `signer.identifier` (or that a delegated-publisher relationship is in effect per a future ADR). For `specific-role-required` sub-types, the role declaration lives in the sub-type's own normative section. For `any-with-binding` sub-types, the attestation's `signer.bindingTier` need only be at least `pseudonymous`.
 - MUST carry the sub-type's required payload fields per the §8.12.1 table.
+- SHOULD use the default content-canonicalization rule (`https://typedstandards.org/canonicalization/legacy-json/v1`; §8.2, §12.3). Attestation payloads are small structured JSON and rarely warrant a bespoke rule; a sub-type MAY name a different rule in its own normative section, and the envelope mechanics are unchanged either way.
 
 #### 8.12.4 Verifier expectations when an original node has one or more attestations
 
@@ -1659,6 +1671,7 @@ The most load-bearing open questions for v0.1 readers and reviewers:
 
 ### Appendix G. Revision history
 
+- **2026-07-01** — Editorial pass from the chat-history extraction evaluation. §5.3 gains the "what this specification is not" boundary list; §8.1 gains the structural-primitive-vs-payload bridge note; §8.2 gains the hash-framing (collision resistance, not uniqueness) note; §8.12.3 gains default content-canonicalization guidance for `attestation/*` nodes; Appendix I expanded (Discourse Graphs / architecture-review / OKFN attribution). No normative mechanics changed.
 - **2026-06-08** — Offline-verifiability graduation (the offline-crypto-hardening arc, [civic-ai-tools-website#119](https://github.com/npstorey/civic-ai-tools-website/issues/119)). §9.4 rewritten: offline verifiability moves from an aspirational target to a demonstrated property of the self-contained commitment bundle (§8.8 `?inline=1`), evidenced by the Q15 offline-bundle harness verifying real production packages at full §9.2 depth with zero network; [Q15](open-questions.md#q15--external-verification-testing) resolved on that basis. §9.2 checks #7 (RFC 3161 TSA signature + X.509 cert-chain to a pinned FreeTSA RSA-4096 root) and #8 (RFC 6962 Rekor Merkle inclusion against a pinned log key + signed checkpoint) marked ENFORCED in `@typedstandards/verify-core@0.6.0`. §10.3 documents the pinned trust anchors with provenance. §9.4 / §10.2 add the offline-snapshot revocation-staleness honest-status note. Scope held precise: [Q1](open-questions.md#q1--package-format) (whether the single-blob package itself embeds its proofs) and [Q16](open-questions.md#q16--formal-conformance-criteria) (formal conformance) stay open.
 - **2026-05-26** — Phase 2 of the Q39 consolidation chat. File renamed from `typed-standards-proposal.md` to `typed-standards-specification.md`. Document title changed from "Typed Standards — proposal" to "Typed Standards Specification". OES §3-§16 and CCV §1-§6 + §8 absorbed into the consolidated body following the 15-section RFC-conventional structure named in the 2026-05-26 deep-research memo §6.1. `ts:` namespace prefix replaces `ccv:` throughout the absorbed typed-claims body; `https://typedstandards.org/ns/ts#` replaces `https://civicaitools.org/ns/civic-claim-vocabulary/v1#` as the vocabulary URI. Well-known trust-registry path renamed from `/.well-known/evidence-public-keys.json` to `/.well-known/typed-publisher.json`; legacy path served in parallel indefinitely (no forced cutover). Status changed from "Internal working draft (pre-v0.1)" to "v0.1 Working Draft — open for external review (review window to be scheduled)". License: CC BY 4.0. New material: §5.5 C2PA + W3C VC disambiguation paragraphs; §6.3 project name + RFC 3161 prefix-choice disambiguation paragraphs; §10 Security Considerations; §11 Privacy Considerations; §12 IANA Considerations; §13 Internationalization Considerations; Appendix A Citation conventions; Appendix D C2PA-to-Typed-Standards term-translation table; Appendix I Acknowledgments. OES + CCV historical-snapshot status notes land in Phase 3 of the consolidation chat (separate commit on the same branch).
 - For earlier revision history of the absorbed OES envelope spec — through 2026-05-25 G4 captureMethod-generalization cohort, 2026-05-25 G3 lifecycle/location cohort, 2026-05-25 G2 unified-primitive cohort, 2026-05-25 G1 envelope-shape cohort, 2026-05-19 datHere reframe, 2026-05-18 datHere captureMethod variant — see [`open-evidence-standard.md`](open-evidence-standard.md) §17 (historical snapshot, frozen 2026-05-26).
@@ -1692,7 +1705,15 @@ The most load-bearing open questions for v0.1 readers and reviewers:
 
 ### Appendix I. Acknowledgments
 
-This specification was developed in collaboration with datHere (Pittsburgh / WPRDC pilot integration partner; the captureMethod profile in §8.7 takes its name from their reference implementation), whose technical input shaped the notebook-format commitment-view schema (§8.8) and the captureMethod content-profile design (§8.6). Additional adopters and contributors will be acknowledged as their participation moves from private to publicly-named status.
+This specification was developed in collaboration with **datHere** (Pittsburgh / WPRDC pilot integration partner; the captureMethod profile in §8.7 takes its name from their reference implementation, embedded with their consent), whose technical input shaped the notebook-format commitment-view schema (§8.8) and the captureMethod content-profile design (§8.6).
+
+The QEC content-type pattern (claim / question / evidence) and the `supportedBy` / `opposedBy` / `answersQuestion` relations are adopted from **Joel Chan's Discourse Graphs work** and the Discourse Graphs community, with attribution carried inline at §5.5 and §7.5.
+
+The layered artifact-layer / network-layer framing and several structural notes on the §7.1 stack were sharpened by an architecture-review conversation with **Michael Zargham** (BlockScience; see the Q41–Q45 origins in [`open-questions.md`](open-questions.md)). The influence is architectural; no endorsement of this specification by the reviewer or BlockScience is implied.
+
+The **Open Knowledge Foundation**'s open-data groundwork (Frictionless Data / the Data Package standard) informs the packaging and portability direction tracked under Q1 and Q18.
+
+Additional adopters and contributors will be acknowledged as their participation moves from private to publicly-named status.
 
 
 

--- a/docs/architecture/typed-standards-specification.md
+++ b/docs/architecture/typed-standards-specification.md
@@ -1709,7 +1709,7 @@ This specification was developed in collaboration with **datHere** (Pittsburgh /
 
 The QEC content-type pattern (claim / question / evidence) and the `supportedBy` / `opposedBy` / `answersQuestion` relations are adopted from **Joel Chan's Discourse Graphs work** and the Discourse Graphs community, with attribution carried inline at §5.5 and §7.5.
 
-The layered artifact-layer / network-layer framing and several structural notes on the §7.1 stack were sharpened by an architecture-review conversation with **Michael Zargham** (BlockScience; see the Q41–Q45 origins in [`open-questions.md`](open-questions.md)). The influence is architectural; no endorsement of this specification by the reviewer or BlockScience is implied.
+The layered artifact-layer / network-layer framing and several structural notes on the §7.1 stack were sharpened by an architecture-review conversation with **Michael Zargham** (BlockScience Dynamical Systems Group; see the Q41–Q45 origins in [`open-questions.md`](open-questions.md)). The influence is architectural; no endorsement of this specification by the reviewer or BlockScience is implied.
 
 The **Open Knowledge Foundation**'s open-data groundwork (Frictionless Data / the Data Package standard) informs the packaging and portability direction tracked under Q1 and Q18.
 

--- a/docs/sustainability.md
+++ b/docs/sustainability.md
@@ -35,6 +35,19 @@ Without adopting commitments that would require a team, funding could accelerate
 - The public, issue-linked roadmap and the ADR process.
 - The out-of-scope list in `ROADMAP.md` Section 7 — including no proprietary data sources, no platform-issued correctness claims, no enterprise SLAs, and no editorial moderation at scale.
 
+## Succession artifact
+
+The succession *trigger* is committed in `ROADMAP.md` Section 3 (#7: no stealth deprecation; any known successor or fork linked). This section records *what a successor would need to hold* — the concrete assets behind the standard and the reference deployment:
+
+- **Domains.** `civicaitools.org` (live) and `typedstandards.org` (registration in flight); registrar accounts are maintainer-held.
+- **Registry signing keys.** The platform Ed25519 signing key (`EVIDENCE_SIGNING_KEY` / `EVIDENCE_KEY_ID`) and the trust-registry contents served at `/.well-known/typed-publisher.json`. Rotation runbook: `civic-ai-tools-website/docs/key-rotation.md`.
+- **The publisher index** reserved at `typedstandards.org` (indexing-only; spec §8.13).
+- **npm scope.** `@typedstandards` (the `verify-core` releases).
+- **Archival DOI.** A Zenodo DOI is deferred to spec v0.2 (ADR-0012); once minted it joins this list.
+- **Fast-handoff contact.** Currently the maintainer (see the reviewer-orientation document); a project inbox is planned alongside the typedstandards.org launch.
+
+All of these are currently maintainer-held — the honest bus-factor-one state this stub exists to disclose. A named custody / handoff arrangement is part of the institutional-stewardship discussion referenced in the community-review orientation document.
+
 ## Accountability
 
 Funded work lands under the same Now/Next/Later structure in `ROADMAP.md`, with the funding relationship disclosed on the affected items. Outputs of funded work remain open-source and open-access. A quarterly refresh surfaces what was funded, what shipped, and what slipped.


### PR DESCRIPTION
Outputs of the 2026-07-01 chat-history extraction evaluation (row-by-row worklist lives in the planning workspace). **Docs-only; no normative mechanics changed.**

## What's in here

**Open-questions registry**
- New entries **Q51–Q58**: SCITT positioning (time-sensitive vs the RFC window) · RFC 9728/CIMD vs the settled well-known trust registry · production-vs-observation attestation + retroactive-wrapping doctrine (corrects a chat-era "settled" that never landed in the ratified §8.12.1 table) · erasure-vs-append-only legal posture · long-horizon verifiability & crypto agility · thin-vs-thick hub topology + key custody · L3 serializations framing (architecture-review note) · RFC-preamble challenge taxonomy
- Annotations: Q1 (in-toto Statement / Sigstore-bundle candidate realization), Q2 (hybrid substrate + KOI stream-primitive sub-question + smallest-probe idea, Xanadu-parked), Q10 (Xanadu reopen flag on the OWL promotion), Q27 (migration-semantics scope + embedded-adopter-profile stake)

**Spec (editorial only)**
- §5.3: "what this specification is not" boundary list (fact-checking / credentialing / KG-format / CMS-SaaS)
- §8.1: structural-primitive-vs-payload bridge note
- §8.2: hash framing — collision resistance under a named, upgradeable algorithm, never uniqueness
- §8.12.3: attestation/* nodes default to `legacy-json/v1` canonicalization
- Appendix I: expanded acknowledgments (Discourse Graphs attribution; architecture-review influence with explicit no-endorsement line; OKFN groundwork)
- Appendix G: revision row

**sustainability.md**
- Succession-artifact section: the concrete assets a successor would need to hold (domains, signing keys, publisher index, npm scope, deferred DOI, handoff contact) — the honest bus-factor-one disclosure

## Review notes
- The Appendix I attribution language is written to attribute influence without implying endorsement — worth a read with that lens.
- Q-numbering: the ADR-0015 PII-reframe stream had informally penciled "~Q51" for its consortia question; that stream should file at Q59+ now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)