### PR TITLE
docs: sync licensing/contributing/registry to typedstandards going public

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Common variables: `Count_Person`, `Median_Income_Person`, `Count_HousingUnit`
 |------|---------|
 | [civic-ai-tools-website](https://github.com/npstorey/civic-ai-tools-website) | Demo website at [civicaitools.org](https://civicaitools.org) — Next.js app with side-by-side MCP comparison |
 | [socrata-mcp-server](https://github.com/npstorey/socrata-mcp-server) | The MCP server itself (Socrata open data portals) |
-| [typedstandards](https://github.com/npstorey/typedstandards) (private) | `@typedstandards/verify-core` on npm + the standalone client-side verifier at [typedstandards.org](https://typedstandards.org) — the neutral home the Typed Standards spec publishes to (ADR-0014) |
+| [typedstandards](https://github.com/npstorey/typedstandards) (public since 2026-07-10) | `@typedstandards/verify-core` on npm + the standalone client-side verifier at [typedstandards.org](https://typedstandards.org) — the neutral home the Typed Standards spec publishes to (ADR-0014) |
 
 Sprint-based work for the website lives in that repo's `/sprints/` folder. This repo holds MCP server configs, skill docs, and setup tooling.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Civic AI Tools spans four repositories. If you're unsure where to file an issue 
 | **[civic-ai-tools](https://github.com/npstorey/civic-ai-tools)** (this repo) | Setup, MCP configs, skill docs, examples, the Typed Standards Specification | [Issues](https://github.com/npstorey/civic-ai-tools/issues) |
 | **[socrata-mcp-server](https://github.com/npstorey/socrata-mcp-server)** | The Socrata MCP server itself | [Issues](https://github.com/npstorey/socrata-mcp-server/issues) |
 | **[civic-ai-tools-website](https://github.com/npstorey/civic-ai-tools-website)** | Demo website at civicaitools.org | [Issues](https://github.com/npstorey/civic-ai-tools-website/issues) |
-| **typedstandards** | typedstandards.org site + `@typedstandards/verify-core` | file here and we'll route |
+| **[typedstandards](https://github.com/npstorey/typedstandards)** | typedstandards.org site + `@typedstandards/verify-core` | [Issues](https://github.com/npstorey/typedstandards/issues) |
 
 Not sure which repo? Open an issue here and we'll route it.
 

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -2,7 +2,7 @@
 
 The single cross-repo record of license choices for the civic-ai-tools project (civic-ai-tools#75; DPG Standard Indicator 2 evidence for the planned DPGA submission, civic-ai-tools#73). Per-repo `LICENSE` files are authoritative for code; this document explains what applies where and why.
 
-**Audited:** 2026-06-11, against the live state of all four repos, the published npm packages, and the specification text.
+**Audited:** 2026-06-11, against the live state of all four repos, the published npm packages, and the specification text. **Updated 2026-07-10:** typedstandards flipped public — row below revised from the "declared at launch" placeholder to the actual MIT declaration.
 
 ## Code
 
@@ -11,7 +11,7 @@ The single cross-repo record of license choices for the civic-ai-tools project (
 | [civic-ai-tools](https://github.com/npstorey/civic-ai-tools) (this repo) | MIT ([LICENSE](LICENSE)) | Hub: MCP configs, setup scripts, skill docs, examples, architecture docs |
 | [civic-ai-tools-website](https://github.com/npstorey/civic-ai-tools-website) | MIT (LICENSE) | Reference implementation + civicaitools.org |
 | [socrata-mcp-server](https://github.com/npstorey/socrata-mcp-server) | MIT (LICENSE, **dual copyright**) | Fork of Scott Robbin's original MCP server; his copyright line and `author` field are preserved alongside the fork's (© 2025 Scott Robbin, © 2025 Nathan Storey). Published on npm under MIT |
-| typedstandards (private pre-launch) | MIT (LICENSE) | The public artifact is [`@typedstandards/verify-core`](https://www.npmjs.com/package/@typedstandards/verify-core) on npm — MIT, with LICENSE shipped in the tarball. When the repo (or the typedstandards.org spec home) goes public, licensing for that surface is declared as part of the launch (see `q3-session-briefs.md` brief #3, D1) |
+| [typedstandards](https://github.com/npstorey/typedstandards) | MIT (LICENSE) | Public since 2026-07-10. Code monorepo — the typedstandards.org site source and [`@typedstandards/verify-core`](https://www.npmjs.com/package/@typedstandards/verify-core) (on npm — MIT, LICENSE shipped in the tarball): all MIT under the repo's [LICENSE](https://github.com/npstorey/typedstandards/blob/main/LICENSE) (© 2026 Nathan Storey). The **specification text** it implements is authored in this repo under CC BY 4.0 (see "Specification text" below); typedstandards carries no separate spec-license surface |
 
 ## Specification text
 

--- a/docs/architecture/open-questions.md
+++ b/docs/architecture/open-questions.md
@@ -596,7 +596,7 @@ A future type-registry mechanism (Q37) governs how new sub-types get registered;
 - **Status.** Open. Decide in the RFC-launch editing pass.
 - **Origin.** 2026-06-26 working session, via extraction row L1; registered 2026-07-01.
 - **Stakes.** Whether the public RFC preamble carries an explicit challenge taxonomy — five challenges named by the maintainer (**Ontological, Telemetric, Legible, Reproducible, Generalizable**) plus five proposed complements (**Adversarial, Adoptive/Incentive, Governance, Temporal, Epistemic**) — and if so, table vs. prose. A stated taxonomy pre-arms reviewers and frames the evaluative questions ("do the seams hold; is the generalization real").
-- **Current direction.** Undecided, including the table-vs-prose presentation question. The definitions currently live only in the 2026-06-26 working-session record, not in any repo — porting them is a precondition for deciding.
+- **Current direction.** Undecided, including the table-vs-prose presentation question. The ten challenge *names* survive above, but their definitions do not: the 2026-06-26 working-session record that held them was declared **unrecoverable on 2026-07-07**. The precondition is therefore no longer "port the definitions" but **re-draft them at the RFC-preamble editing pass** (the Stakes names are the seed).
 - **Resolution criteria.** The RFC-launch editing pass either adopts the taxonomy into the preamble or drops it with a recorded reason.
 - **Notes.** Worklist row L1.
 


### PR DESCRIPTION
Post-flip doc sync for the **typedstandards → public** flip (2026-07-10, quiet go-live). This is checklist step 6 of `typedstandards-public-flip-checklist.md` (planning repo) — the civic-ai-tools-repo portion.

## What changed
- **LICENSING.md** — typedstandards row: drops the "private pre-launch" tag and the "declared at launch" placeholder; declares the actual public-surface licensing. The repo is a code monorepo (typedstandards.org site source + `@typedstandards/verify-core`), all **MIT** under the repo LICENSE (© 2026 Nathan Storey). The **specification text** it implements stays authored here under **CC BY 4.0** — typedstandards carries no separate spec-license surface. Header gains a dated update note (the file's maintenance trigger is "a repo goes public").
- **CONTRIBUTING.md** — typedstandards row gains real repo + Issues links (they resolve publicly now); the old "file here and we'll route" placeholder is retired.
- **CLAUDE.md** (this repo's) — related-repos table drops the `(private)` tag → `(public since 2026-07-10)`.
- **docs/architecture/open-questions.md (Q58 rider)** — the 2026-06-26 challenge-taxonomy definitions were declared **unrecoverable on 2026-07-07**; Q58's precondition changes from "port the definitions" to "**re-draft them at the RFC-preamble pass**". The ten challenge *names* are preserved in the Stakes line.

## Out of scope (different repo, no cross-commit)
The **workspace CLAUDE.md** branching-discipline fix (it wrongly says typedstandards "cannot carry a ruleset on the free plan") + checklist retirement land in `civic-ai-tools-planning` separately.

## Verification
- Repo confirmed public: `private:false`, `visibility:public`, default branch `main`.
- **protect-main ruleset active** on typedstandards (applied ops-side, checklist step 5): **id 18791625**, enforcement `active`, rules on main = `deletion` + `non_fast_forward` + `pull_request` (required, 0 approvals, all merge methods). Verified, not re-created.

DCO signed-off. 🤖 Generated with [Claude Code](https://claude.com/claude-code)