### PR TITLE
docs: ADR-0021 → Accepted (status flip)

### DIFF
--- a/docs/adr/0021-produce-core-extraction.md
+++ b/docs/adr/0021-produce-core-extraction.md
@@ -1,7 +1,7 @@
 # ADR-0021: Producer-side core extraction (`@typedstandards/produce-core`) and the format/domain line (Q59)
 
-- **Status:** **Proposed** — drafted 2026-07-31 by an orchestration session per Stream 1 of the civic-data-analysis stack program; decision pending maintainer review. On acceptance, [Q59](../architecture/open-questions.md#q59--producer-side-core-no-portable-counterpart-to-verify-core) resolves via its option (a), contingent on the demonstration named in §Consequences.
-- **Date:** 2026-07-31 (draft)
+- **Status:** **Accepted** 2026-07-31 (maintainer review; merged #113 — drafted the same day by an orchestration session per Stream 1 of the civic-data-analysis stack program). [Q59](../architecture/open-questions.md#q59--producer-side-core-no-portable-counterpart-to-verify-core) resolves via its option (a) **contingent on the demonstration named in §Consequences**; the registry flip rides that demonstration, not this acceptance.
+- **Date:** 2026-07-31 (decision + draft)
 - **Decision-maker:** Solo maintainer
 - **Supersedes:** —
 - **Superseded by:** —


### PR DESCRIPTION
One-hunk follow-up to #113: flips ADR-0021's Status line to **Accepted 2026-07-31** (the review happened, the merge happened, the line just didn't get edited in flight).

Deliberately does **not** touch the Q59 registry entry — per the ADR, Q59 moves to the resolution log only when the independent-producer demonstration ships, and open-questions.md edits stay clear of the frozen `registry/q61-q64` merge-order constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)