### PR TITLE
harness: civic-typed-harness package — workspaces + domain port + ADR-0022 (S2 P1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ analysis_results.json
 *.output.json
 output/
 
+# Node (npm workspaces since S2)
+node_modules/
+
 # Python
 __pycache__/
 *.py[cod]

--- a/docs/adr/0022-civic-typed-harness-packaging.md
+++ b/docs/adr/0022-civic-typed-harness-packaging.md
@@ -1,0 +1,68 @@
+# ADR-0022: Civic-harness packaging — npm workspaces and the first package in the hub repo
+
+- **Status:** Proposed
+- **Date:** 2026-08-01 (drafted by the S2 P1 implementation session, riding its PR per the sprint's G0 decision 1)
+- **Decision-maker:** Solo maintainer
+- **Supersedes:** —
+- **Superseded by:** —
+- **Evolves:** [ADR-0021](0021-produce-core-extraction.md) (the format/domain line — this ADR lands the DOMAIN side of that line as a package), [ADR-0019](0019-reference-app-posture.md) (the importable-package adoption layer, now extended to the civic domain), [ADR-0020](0020-instance-key-custody.md) (the parameterization posture the harness's config-not-constants rule implements at the domain layer)
+
+*Numbering note: 0018 remains reserved for the roadmap-governance amendment; 0019–0021 are taken (confirmed against the working tree at drafting time).*
+
+## Context
+
+ADR-0021 §B drew the format/domain line and deliberately left the DOMAIN column behind in the reference app: the `civic:` vocabulary and `urn:civic-evidence:` scheme, the datHere derivations, and the capture machinery (TraceBuilder, span-walking extraction, data-source population, the adversarial rubric core). Its §Consequences named the follow-through: *"the civic harness relocation (Stream 2) picks up the domain side of the line."* This ADR records the packaging decisions that relocation forces on the hub repo.
+
+`civic-ai-tools` has until now been a starter/docs repo — MCP configs, skill docs, setup scripts, the architecture documents, and the specification's canonical home. Landing the harness as *code* makes it what the stack program plan calls it: the civic-domain-harness spec + method, with the code to match. That is a purpose expansion for a public repo, worth a decision record.
+
+## Decision
+
+### A. npm workspaces at the repo root; `packages/civic-typed-harness` is the first (and only) package
+
+The root `package.json` gains `workspaces: ["packages/*"]` and stays `private: true`. The harness is the only package this decision introduces; nothing else in the repo moves into a package. The relocation is **purely additive**: the reference app keeps its in-repo copies until the S3 re-point migrates it onto `produce-core` + the harness in one move.
+
+### B. Working name, publish deferred
+
+The package's working name is **`civic-typed-harness`** (sprint G0 decision 2, adopting the layering sketch's layer-3 name). The final npm name/scope is deferred to the project's naming taxonomy and gates only *publishing*, not the code landing. **No npm publish this sprint** (G0 decision 3): the package is `private: true` and publishes when S3 is ready to consume both packages together, avoiding naming churn on the registry.
+
+### C. One package, two module groups — the boundary is the hedge
+
+Internally the package holds two cleanly separated module groups plus a small third:
+
+- **format-extension** (`src/format/`) — what extends the *standard*: the `civic:` vocabulary and id scheme, the civic source registry, the datHere policy derivations, the captureMethod vocabulary surface (re-exported from verify-core's Q32 fallback table — flagged, not solved).
+- **capture** (`src/capture/`) — what *produces* under it: TraceBuilder, skill-metadata extraction, data-source population, and the provenance *builder*, which imports its vocabulary from the format-extension group.
+- **rubric** (`src/rubric/`) — the adversarial-evaluation pure core, with its Q26-pinned `RUBRIC_VERSION_SHA256` preserved byte-exactly across the move.
+
+The boundary is normative and mechanically enforced (purity test): no capture module defines vocabulary; no format-extension module walks a trace. Rationale: the naming-taxonomy input distinguishes a civic extension *of Typed Standards* from the civic *harness* proper — holding the boundary now makes that outcome a mechanical package split later instead of a re-partition, at near-zero present cost.
+
+### D. Harness-grade purity; config-not-constants
+
+The package carries verify-core/produce-core's purity discipline one notch looser, as the domain layer requires: no I/O, no environment reads, no Node built-ins, browser-safe — everywhere; clock + RNG **in capture modules only** (timestamps and span ids are what capture *is*), injectable for tests. Enforced the same way as the cores: ESLint restricted-imports/globals plus a dependency-free purity test.
+
+Every value naming a deployment — platform-agent identity/URL, MCP server URLs, the environment-extension `host`, trace `service.name` — is a typed config input with the civicaitools.org demo values as exported defaults. This is where S2 meets the ADR-0020/S3 parameterization set: the harness *accepts* instance values; it hardcodes none.
+
+### E. Runtime dependency: `@typedstandards/produce-core` (^0.1.0) only
+
+The harness derives; the core assembles (ADR-0021's operating rule). `verify-core` arrives transitively through produce-core's own pinned dependency and is imported directly for primitives produce-core does not re-export (`sha256Hex`, `isBlobRef`, the canonicalization-rule URIs, the Q32 vocabulary table) — producer, harness, and verifier share one hashing implementation by construction. No framework, no DB, no fetch.
+
+## Considered and rejected
+
+- **Keep the domain code in the app; publish only the format core.** Rejected by ADR-0021's own consequences: a prospective instance would have to copy application internals to emit civic-conformant packages — the divergent-fork risk Q59 named, reproduced one layer up.
+- **Two packages now (civic extension vs capture harness).** Premature: no adopter needs them separately yet (Xanadu gate), and the naming taxonomy that would name the split is unresolved. The §C module boundary buys the same optionality at near-zero cost.
+- **A separate repo for the harness.** Rejected: the hub repo already holds the civic method's docs, dataset directory, and skill guidance — S2 brings the code to where the method already lives; a third repo adds coordination surface without a consumer asking for it.
+- **Publish to npm now under the working name.** Rejected (G0 decision 3): renaming a published package later costs registry churn for zero present benefit; nothing consumes the package until S3.
+
+## Consequences
+
+- The reference app is untouched by this decision; S3 re-points it at `produce-core` + the harness in one migration and deletes the in-repo copies.
+- Byte-compatibility is the acceptance bar for the relocation: with demo-default config, the harness reproduces the reference implementation's provenance graphs, dataSources arrays, and rubric version hash byte-for-byte (golden-parity tests ride the package; full fixture-level proof against produce-core's `reference-golden.json` and the produce→verify composition round-trip are the next sprint phase).
+- The repo's contributor surface grows a Node toolchain (workspaces install, `npm test --workspaces`). CI wiring for the workspace is follow-up work.
+- When the naming taxonomy lands, the rename (and any §C package split) is a mechanical move; this ADR gets a companion recording the final name rather than an amendment re-arguing the shape.
+
+## References
+
+- [ADR-0021](0021-produce-core-extraction.md) — the format/domain line; §B's DOMAIN column is this package's contents.
+- [ADR-0019](0019-reference-app-posture.md), [ADR-0020](0020-instance-key-custody.md) — the adoption-layer and parameterization posture.
+- `packages/civic-typed-harness/README.md` — module map, config surface, purity contract, and the boundary sentence reserving the future split.
+- Typed Standards Specification §8.6 (profile-governed vocabularies), §8.9 (PROV-O), §9.1 (conformant publisher).
+- Stream 2 brief (planning-side): `stream2-civic-harness-brief.md` — the function-level partition and G0 decisions this ADR records the packaging half of.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1541 @@
+{
+  "name": "civic-ai-tools",
+  "version": "0.5.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "civic-ai-tools",
+      "version": "0.5.0",
+      "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ]
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@typedstandards/produce-core": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@typedstandards/produce-core/-/produce-core-0.1.0.tgz",
+      "integrity": "sha512-W6dXS1f8vEJM12vFeLTUKPiuitsPqC3ndLkr4+8WiPI1aXUDNdW6gcelD7eXbBA32V8bAgsP8cxe4ALMxIMdeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "^2.2.0",
+        "@typedstandards/verify-core": "^0.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@typedstandards/verify-core": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@typedstandards/verify-core/-/verify-core-0.7.0.tgz",
+      "integrity": "sha512-2Bm26/ry2G57p3PaKogCkf2j001IMrU/lgh84kTIRJl4GvazVzACFS2imI4tYQrIqjL2JCfE3InaJCgSWhupqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/curves": "^2.2.0",
+        "@noble/hashes": "^2.2.0",
+        "canonicalize": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/canonicalize": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-3.0.0.tgz",
+      "integrity": "sha512-yYLfHyDMIXRyRqsKBRLX023riFLpXY2YOfdtqKXZRZy9qsfOJ9U+4F9YZL7MEzL5+ziN2x2nlBvY/Voi3EBljA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/civic-typed-harness": {
+      "resolved": "packages/civic-typed-harness",
+      "link": true
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/eslint/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/civic-typed-harness": {
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@typedstandards/produce-core": "^0.1.0"
+      },
+      "devDependencies": {
+        "@typescript-eslint/parser": "^8",
+        "eslint": "^9",
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "license": "MIT",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "validate-directory": "node scripts/validate-directory.mjs",
     "generate-directory-md": "node scripts/generate-directory-md.mjs",

--- a/packages/civic-typed-harness/LICENSE
+++ b/packages/civic-typed-harness/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Nathan Storey
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/civic-typed-harness/README.md
+++ b/packages/civic-typed-harness/README.md
@@ -1,0 +1,49 @@
+# civic-typed-harness
+
+The civic **domain harness** for [Typed Standards](../../docs/architecture/typed-standards-specification.md) evidence packages — the DOMAIN side of the format/domain line drawn in [ADR-0021](../../docs/adr/0021-produce-core-extraction.md), relocated from the reference app as an installable package ([ADR-0022](../../docs/adr/0022-civic-typed-harness-packaging.md)). The operating rule: **the harness derives, the core assembles** — everything here produces domain-derived values (civic vocabulary terms, datHere policy fields, provenance graphs, capture artifacts) that feed [`@typedstandards/produce-core`](https://www.npmjs.com/package/@typedstandards/produce-core)'s neutral envelope assembly.
+
+> **Working name.** `civic-typed-harness` is the working name (sprint G0 decision); the final npm name/scope is deferred to the project's naming taxonomy and only gates *publishing*, not this code. The package is `private: true` and is **not published to npm** — it will publish when the reference app is ready to consume it (S3).
+
+## What's inside
+
+| Module group | Modules | What it is |
+|---|---|---|
+| **`src/format/`** — the civic format-extension | `vocabulary.ts`, `sources.ts`, `dathere.ts`, `profiles.ts` | What extends the *standard*: the `civic:` JSON-LD namespace and `urn:civic-evidence:` id scheme, the civic source registry, the datHere envelope-policy derivations (producerProfile, canonicalization rule, summary emission, environment extension), and the captureMethod vocabulary surface. |
+| **`src/capture/`** — the capture machinery | `trace.ts`, `skill-metadata.ts`, `data-sources.ts`, `provenance.ts` | What *produces* under it: the OTel `TraceBuilder`, skill-metadata extraction, data-source population, and the provenance **builder** — which imports its vocabulary from the format group and walks the trace. |
+| **`src/rubric/`** — the adversarial rubric | `adversarial-eval-core.ts` | The civic six-criterion evaluation rubric (pure core: rubric text, pinned version hash, prompt builder, response parser). The model runner and result emission stay implementation-side. |
+
+**The internal boundary is load-bearing:** no capture module defines vocabulary, and no format-extension module walks a trace — this sentence reserves a future split of the format-extension group into its own package (a civic extension *of Typed Standards*, distinct from the civic *harness* proper) as a mechanical move rather than a re-partition. The boundary is enforced by `src/purity.test.ts`.
+
+## Config, not constants
+
+Every value that names a deployment is a **typed config input**, with the civicaitools.org demo values exported as overridable defaults:
+
+| Value | Config type | Demo default export |
+|---|---|---|
+| Platform-agent identity/URL | `PlatformAgentConfig` | `CIVICAITOOLS_PLATFORM_AGENT` |
+| MCP source registry (server URLs, catalog types, display names) | `CivicSourceRegistry` | `CIVIC_SOURCE_REGISTRY` |
+| Tool-name → source-id resolver | `ToolSourceResolver` | `civicToolSourceResolver` |
+| Environment-extension `host` | `DatHereEnvironmentConfig` | `CIVICAITOOLS_ENVIRONMENT_CONFIG` |
+| Trace `service.name` / scope identity | `TraceBuilderConfig` | `CIVICAITOOLS_TRACE_CONFIG` |
+| Provenance build (all of the above + model-agent description) | `ProvenanceConfig` | `CIVICAITOOLS_PROVENANCE_CONFIG` |
+
+## Purity contract (harness-grade)
+
+No I/O, no network, no environment reads, no Node built-ins, browser-safe — anywhere in the package. Clock and RNG are permitted **in capture modules only** (span timestamps and ids are what capture *is*) and are injectable for deterministic tests. Enforced mechanically twice: `eslint.config.mjs` (`no-restricted-imports` / `-globals` / `-properties` / `-syntax`) and `src/purity.test.ts` (browser-safety + determinism + module-boundary checks under `node --test`).
+
+Runtime dependency: **`@typedstandards/produce-core` only.** `@typedstandards/verify-core` arrives transitively through it (pinned by produce-core's own dependency) and is imported directly for the primitives produce-core does not re-export (`sha256Hex`, `isBlobRef`, the canonicalization-rule URIs, the Q32 vocabulary table) — one hashing implementation across producer, harness, and verifier by construction.
+
+> **Q32 adjacency** (open-questions registry): the captureMethod vocabulary re-exported from `src/format/profiles.ts` is verify-core's hardcoded fallback table, pending versioned, content-addressed guidance bundles. Flagged, not solved, here.
+
+## Byte-compatibility
+
+The port is tested for **byte parity** against golden outputs captured from the reference implementation (`src/__fixtures__/website-golden.json`): with the demo default config, `buildProvenanceGraph` and `buildDataSources` reproduce the app's output byte-for-byte, and `RUBRIC_VERSION_SHA256` is asserted against the exact reference digest (moving the rubric changes no hashes). Full fixture-level byte-compat against produce-core's `reference-golden.json` and the produce→verify composition round-trip land in the next sprint phase.
+
+## Develop
+
+```bash
+npm install          # from the repo root (npm workspaces)
+npm test  --workspace civic-typed-harness
+npm run lint  --workspace civic-typed-harness
+npm run build --workspace civic-typed-harness
+```

--- a/packages/civic-typed-harness/eslint.config.mjs
+++ b/packages/civic-typed-harness/eslint.config.mjs
@@ -1,0 +1,107 @@
+// Purity guard for civic-typed-harness (harness-grade, per the S2 brief §2 —
+// one notch looser than produce-core's core-grade contract).
+//
+// The whole package is I/O-free and browser-safe: no Node built-ins, no
+// environment reads, no network, no Buffer. Clock + RNG are additionally
+// banned in the FORMAT-EXTENSION and RUBRIC module groups; they are permitted
+// in the CAPTURE group only (span timestamps and ids are what capture *is*),
+// where they must be injectable for deterministic tests. The dependency-free
+// `purity.test.ts` enforces the same contract (plus the format/capture module
+// boundary) mechanically under `node --test`. Test files are exempt from the
+// import ban: they legitimately use `node:test` / `node:fs` to build fixtures.
+
+import parser from '@typescript-eslint/parser';
+
+// Bare specifiers that resolve to Node built-ins; the `node:*` pattern below
+// covers every prefixed form.
+const FORBIDDEN_BARE_IMPORTS = [
+  'crypto',
+  'fs',
+  'fs/promises',
+  'path',
+  'process',
+];
+
+export default [
+  // Whole package: I/O-free, env-free, browser-safe.
+  {
+    files: ['src/**/*.ts'],
+    ignores: ['src/**/*.test.ts'],
+    languageOptions: { parser },
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: FORBIDDEN_BARE_IMPORTS.map((name) => ({
+            name,
+            message: `civic-typed-harness is I/O-free and browser-safe — do not import "${name}". Use @typedstandards/verify-core primitives (via produce-core's dependency), or take the value as a caller-supplied config input.`,
+          })),
+          patterns: [
+            {
+              group: ['node:*'],
+              message:
+                'civic-typed-harness is I/O-free and browser-safe — no node:* imports in shipped source.',
+            },
+          ],
+        },
+      ],
+      'no-restricted-globals': [
+        'error',
+        {
+          name: 'process',
+          message:
+            'No environment reads — every instance-naming value (platform agent, server URLs, environment host, trace service.name) is a typed config input with the demo values as exported defaults.',
+        },
+        {
+          name: 'Buffer',
+          message:
+            'Buffer is Node-only — use Uint8Array / atob / btoa / verify-core primitives.',
+        },
+      ],
+    },
+  },
+  // Non-capture groups (format-extension, rubric, index): additionally
+  // deterministic — no clock, no RNG. Capture modules (src/capture/**) are
+  // exempt from THIS block only: timestamps and span ids are what capture is,
+  // and both are injectable there for tests.
+  {
+    files: ['src/format/**/*.ts', 'src/rubric/**/*.ts', 'src/index.ts'],
+    ignores: ['src/**/*.test.ts'],
+    languageOptions: { parser },
+    rules: {
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'Date',
+          property: 'now',
+          message:
+            'Clock reads are capture-only (src/capture/**) — format-extension and rubric modules are deterministic.',
+        },
+        {
+          object: 'Math',
+          property: 'random',
+          message:
+            'RNG is capture-only (src/capture/**) — format-extension and rubric modules are deterministic.',
+        },
+      ],
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: "NewExpression[callee.name='Date']",
+          message:
+            'Clock reads are capture-only (src/capture/**) — format-extension and rubric modules are deterministic.',
+        },
+        {
+          selector: "CallExpression[callee.property.name='randomUUID']",
+          message:
+            'RNG is capture-only (src/capture/**) — ids are caller-supplied or capture-generated.',
+        },
+        {
+          selector: "CallExpression[callee.property.name='getRandomValues']",
+          message:
+            'RNG is capture-only (src/capture/**) — ids are caller-supplied or capture-generated.',
+        },
+      ],
+    },
+  },
+];

--- a/packages/civic-typed-harness/package.json
+++ b/packages/civic-typed-harness/package.json
@@ -1,0 +1,58 @@
+{
+  "name": "civic-typed-harness",
+  "version": "0.1.0",
+  "description": "Civic-domain harness for Typed Standards evidence packages — the DOMAIN layer of the ADR-0021 format/domain line: civic PROV-O vocabulary and provenance builder, datHere envelope-policy derivations, and the capture machinery (trace builder, skill-metadata extraction, data-source population, adversarial rubric core). Derives; @typedstandards/produce-core assembles.",
+  "license": "MIT",
+  "author": "Nathan Storey",
+  "private": true,
+  "type": "module",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "lint": "eslint .",
+    "test": "node --test --experimental-strip-types \"src/**/*.test.ts\""
+  },
+  "dependencies": {
+    "@typedstandards/produce-core": "^0.1.0"
+  },
+  "devDependencies": {
+    "@typescript-eslint/parser": "^8",
+    "eslint": "^9",
+    "typescript": "^5.9.3"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/npstorey/civic-ai-tools.git",
+    "directory": "packages/civic-typed-harness"
+  },
+  "keywords": [
+    "typed-standards",
+    "evidence",
+    "provenance",
+    "civic",
+    "harness",
+    "prov-o",
+    "otel"
+  ]
+}

--- a/packages/civic-typed-harness/src/__fixtures__/website-golden.json
+++ b/packages/civic-typed-harness/src/__fixtures__/website-golden.json
@@ -1,0 +1,810 @@
+{
+  "//": "Golden fixtures captured 2026-08-01 (regenerated same day) from civic-ai-tools-website src/lib/evidence (provenance.ts, data-sources.ts) — the byte-parity reference for the harness port. Fixture convention: synthetic span timestamps stay under 13 digits so they cannot pattern-match as card/account numbers in pre-push sensitivity scans.",
+  "provenanceInput": {
+    "packageId": "pkg-golden-001",
+    "promptHash": "prompthash123",
+    "promptText": "How many noise complaints were filed in 2025?",
+    "outputText": "There were 12 complaints.",
+    "model": "openai/gpt-4o",
+    "portal": "data.cityofnewyork.us"
+  },
+  "trace": {
+    "resourceSpans": [
+      {
+        "scopeSpans": [
+          {
+            "spans": [
+              {
+                "name": "skill_fetch",
+                "spanId": "skill-span-1",
+                "attributes": [
+                  {
+                    "key": "skill.text_hash",
+                    "value": {
+                      "stringValue": "aaa111"
+                    }
+                  },
+                  {
+                    "key": "skill.mcp_server_url",
+                    "value": {
+                      "stringValue": "https://socrata-mcp.civicaitools.org"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "llm_inference",
+                "spanId": "inf-1",
+                "startTimeUnixNano": "1000000000",
+                "endTimeUnixNano": "2000000000",
+                "attributes": [
+                  {
+                    "key": "gen_ai.inference_index",
+                    "value": {
+                      "stringValue": "0"
+                    }
+                  },
+                  {
+                    "key": "gen_ai.response.prompt_tokens",
+                    "value": {
+                      "stringValue": "120"
+                    }
+                  },
+                  {
+                    "key": "gen_ai.response.completion_tokens",
+                    "value": {
+                      "stringValue": "45"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "mcp_tool_call",
+                "spanId": "tool-1",
+                "startTimeUnixNano": "3000000000",
+                "endTimeUnixNano": "4000000000",
+                "attributes": [
+                  {
+                    "key": "mcp.source",
+                    "value": {
+                      "stringValue": "socrata"
+                    }
+                  },
+                  {
+                    "key": "tool.name",
+                    "value": {
+                      "stringValue": "get_data"
+                    }
+                  },
+                  {
+                    "key": "tool.operation_type",
+                    "value": {
+                      "stringValue": "query"
+                    }
+                  },
+                  {
+                    "key": "tool.arguments",
+                    "value": {
+                      "stringValue": "{\"type\":\"query\",\"dataset_id\":\"erm2-nwe9\"}"
+                    }
+                  },
+                  {
+                    "key": "tool.response_hash",
+                    "value": {
+                      "stringValue": "bbb222"
+                    }
+                  },
+                  {
+                    "key": "tool.dataset_id",
+                    "value": {
+                      "stringValue": "erm2-nwe9"
+                    }
+                  },
+                  {
+                    "key": "tool.portal_domain",
+                    "value": {
+                      "stringValue": "data.cityofnewyork.us"
+                    }
+                  },
+                  {
+                    "key": "tool.response_rows",
+                    "value": {
+                      "stringValue": "12"
+                    }
+                  },
+                  {
+                    "key": "tool.duration_ms",
+                    "value": {
+                      "stringValue": "850"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "mcp_tool_call",
+                "spanId": "tool-2",
+                "startTimeUnixNano": "5000000000",
+                "endTimeUnixNano": "6000000000",
+                "attributes": [
+                  {
+                    "key": "mcp.source",
+                    "value": {
+                      "stringValue": "data-commons"
+                    }
+                  },
+                  {
+                    "key": "tool.name",
+                    "value": {
+                      "stringValue": "get_observations"
+                    }
+                  },
+                  {
+                    "key": "tool.operation_type",
+                    "value": {
+                      "stringValue": "query"
+                    }
+                  },
+                  {
+                    "key": "tool.arguments",
+                    "value": {
+                      "stringValue": "{\"variable_dcid\":\"Count_Person\"}"
+                    }
+                  },
+                  {
+                    "key": "tool.response_hash",
+                    "value": {
+                      "stringValue": "ccc333"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "mcp_tool_call",
+                "spanId": "tool-3",
+                "startTimeUnixNano": "7000000000",
+                "endTimeUnixNano": "8000000000",
+                "attributes": [
+                  {
+                    "key": "mcp.source",
+                    "value": {
+                      "stringValue": "boston-opencontext"
+                    }
+                  },
+                  {
+                    "key": "tool.name",
+                    "value": {
+                      "stringValue": "ckan__aggregate_data"
+                    }
+                  },
+                  {
+                    "key": "tool.operation_type",
+                    "value": {
+                      "stringValue": "query"
+                    }
+                  },
+                  {
+                    "key": "tool.arguments",
+                    "value": {
+                      "stringValue": "{\"resource_id\":\"abc\"}"
+                    }
+                  },
+                  {
+                    "key": "tool.response_hash",
+                    "value": {
+                      "stringValue": "ddd444"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "mcp_tool_call",
+                "spanId": "tool-4",
+                "startTimeUnixNano": "9000000000",
+                "endTimeUnixNano": "10000000000",
+                "attributes": [
+                  {
+                    "key": "mcp.source",
+                    "value": {
+                      "stringValue": "euro stat"
+                    }
+                  },
+                  {
+                    "key": "tool.name",
+                    "value": {
+                      "stringValue": "mystery_tool"
+                    }
+                  },
+                  {
+                    "key": "tool.operation_type",
+                    "value": {
+                      "stringValue": "query"
+                    }
+                  },
+                  {
+                    "key": "tool.arguments",
+                    "value": {
+                      "stringValue": "{\"q\":\"x\"}"
+                    }
+                  },
+                  {
+                    "key": "tool.response_hash",
+                    "value": {
+                      "stringValue": "eee555"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "mcp_tool_call",
+                "spanId": "tool-5",
+                "startTimeUnixNano": "11000000000",
+                "endTimeUnixNano": "12000000000",
+                "attributes": [
+                  {
+                    "key": "tool.name",
+                    "value": {
+                      "stringValue": "get_data"
+                    }
+                  },
+                  {
+                    "key": "tool.operation_type",
+                    "value": {
+                      "stringValue": "metadata"
+                    }
+                  },
+                  {
+                    "key": "tool.arguments",
+                    "value": {
+                      "stringValue": "{\"type\":\"metadata\",\"dataset_id\":\"43nn-pn8j\"}"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "llm_inference",
+                "spanId": "inf-2",
+                "startTimeUnixNano": "13000000000",
+                "endTimeUnixNano": "14000000000",
+                "attributes": [
+                  {
+                    "key": "gen_ai.inference_index",
+                    "value": {
+                      "stringValue": "1"
+                    }
+                  }
+                ]
+              },
+              {
+                "name": "synthesis",
+                "spanId": "synth-1",
+                "startTimeUnixNano": "15000000000",
+                "endTimeUnixNano": "16000000000",
+                "attributes": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "provenanceGraph": {
+    "@context": {
+      "prov": "http://www.w3.org/ns/prov#",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "civic": "https://civicaitools.org/ns/evidence/",
+      "dcterms": "http://purl.org/dc/terms/"
+    },
+    "@graph": [
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:prompt:prompthash123",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:prompthash123",
+        "dcterms:description": "User query prompt",
+        "prov:value": "How many noise complaints were filed in 2025?"
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:skill:aaa111",
+        "@type": [
+          "prov:Entity",
+          "prov:Plan"
+        ],
+        "civic:contentHash": "sha256:aaa111",
+        "dcterms:description": "Composed MCP skill guidance (system prompt)"
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:output:123571add9bd101d35ab7e7da90b5710d0d98eb8ac494c94c3c7b1cee8aac577",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:123571add9bd101d35ab7e7da90b5710d0d98eb8ac494c94c3c7b1cee8aac577",
+        "dcterms:description": "AI-generated analysis output"
+      },
+      {
+        "@id": "urn:civic-evidence:model:openai-gpt-4o",
+        "@type": [
+          "prov:Agent",
+          "prov:SoftwareAgent"
+        ],
+        "dcterms:title": "openai/gpt-4o",
+        "dcterms:description": "Large language model via OpenRouter"
+      },
+      {
+        "@id": "urn:civic-evidence:mcp-server:socrata",
+        "@type": [
+          "prov:Agent",
+          "prov:SoftwareAgent"
+        ],
+        "dcterms:title": "Socrata MCP Server",
+        "civic:serverUrl": "https://socrata-mcp.civicaitools.org",
+        "civic:sourceId": "socrata"
+      },
+      {
+        "@id": "urn:civic-evidence:mcp-server:data-commons",
+        "@type": [
+          "prov:Agent",
+          "prov:SoftwareAgent"
+        ],
+        "dcterms:title": "Google Data Commons MCP Server",
+        "civic:serverUrl": "https://api.datacommons.org/mcp",
+        "civic:sourceId": "data-commons"
+      },
+      {
+        "@id": "urn:civic-evidence:mcp-server:boston-opencontext",
+        "@type": [
+          "prov:Agent",
+          "prov:SoftwareAgent"
+        ],
+        "dcterms:title": "Boston OpenContext MCP Server",
+        "civic:serverUrl": "https://data-mcp.boston.gov/mcp",
+        "civic:sourceId": "boston-opencontext"
+      },
+      {
+        "@id": "urn:civic-evidence:mcp-server:euro%20stat",
+        "@type": [
+          "prov:Agent",
+          "prov:SoftwareAgent"
+        ],
+        "dcterms:title": "euro stat MCP Server",
+        "civic:serverUrl": "euro stat",
+        "civic:sourceId": "euro stat"
+      },
+      {
+        "@id": "urn:civic-evidence:platform:civic-ai-tools",
+        "@type": [
+          "prov:Agent",
+          "prov:SoftwareAgent"
+        ],
+        "dcterms:title": "Civic AI Tools",
+        "civic:url": "https://civicaitools.org"
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:inference:inf-1",
+        "@type": "prov:Activity",
+        "dcterms:description": "LLM inference call (iteration 0)",
+        "prov:wasAssociatedWith": {
+          "@id": "urn:civic-evidence:model:openai-gpt-4o"
+        },
+        "prov:used": [
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:prompt:prompthash123"
+          },
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:skill:aaa111"
+          }
+        ],
+        "prov:startedAtTime": {
+          "@value": "1970-01-01T00:00:01.000Z",
+          "@type": "xsd:dateTime"
+        },
+        "prov:endedAtTime": {
+          "@value": "1970-01-01T00:00:02.000Z",
+          "@type": "xsd:dateTime"
+        },
+        "civic:promptTokens": 120,
+        "civic:completionTokens": 45
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:inference:inf-2",
+        "@type": "prov:Activity",
+        "dcterms:description": "LLM inference call (iteration 1)",
+        "prov:wasAssociatedWith": {
+          "@id": "urn:civic-evidence:model:openai-gpt-4o"
+        },
+        "prov:used": [
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:prompt:prompthash123"
+          },
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:skill:aaa111"
+          },
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:data:bbb222"
+          },
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:data:ccc333"
+          },
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:data:ddd444"
+          },
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:data:eee555"
+          }
+        ],
+        "prov:startedAtTime": {
+          "@value": "1970-01-01T00:00:13.000Z",
+          "@type": "xsd:dateTime"
+        },
+        "prov:endedAtTime": {
+          "@value": "1970-01-01T00:00:14.000Z",
+          "@type": "xsd:dateTime"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:query:bb4ba745d8c8cad9aa349d4e36b5d0042a936dce26140ee1e36140acce425736",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:bb4ba745d8c8cad9aa349d4e36b5d0042a936dce26140ee1e36140acce425736",
+        "civic:toolName": "get_data",
+        "civic:operationType": "query",
+        "dcterms:description": "MCP tool arguments (query)",
+        "prov:wasGeneratedBy": {
+          "@id": "urn:civic-evidence:pkg-golden-001:inference:inf-1"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:data:bbb222",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:bbb222",
+        "dcterms:description": "Data response from data.cityofnewyork.us",
+        "civic:sourceId": "socrata",
+        "prov:wasGeneratedBy": {
+          "@id": "urn:civic-evidence:pkg-golden-001:tool-call:tool-1"
+        },
+        "civic:datasetId": "erm2-nwe9",
+        "civic:portalDomain": "data.cityofnewyork.us",
+        "civic:datasetUrl": "https://data.cityofnewyork.us/d/erm2-nwe9",
+        "civic:croissantMetadataUrl": null,
+        "civic:responseRows": 12
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:tool-call:tool-1",
+        "@type": "prov:Activity",
+        "dcterms:description": "MCP tool call: get_data (query)",
+        "civic:sourceId": "socrata",
+        "prov:used": [
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:query:bb4ba745d8c8cad9aa349d4e36b5d0042a936dce26140ee1e36140acce425736"
+          }
+        ],
+        "prov:wasAssociatedWith": {
+          "@id": "urn:civic-evidence:mcp-server:socrata"
+        },
+        "prov:startedAtTime": {
+          "@value": "1970-01-01T00:00:03.000Z",
+          "@type": "xsd:dateTime"
+        },
+        "prov:endedAtTime": {
+          "@value": "1970-01-01T00:00:04.000Z",
+          "@type": "xsd:dateTime"
+        },
+        "civic:durationMs": 850
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:query:9fa0829aba3b6663a521ece5820717e7dee55c346681fa53f29b36044fe3fd35",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:9fa0829aba3b6663a521ece5820717e7dee55c346681fa53f29b36044fe3fd35",
+        "civic:toolName": "get_observations",
+        "civic:operationType": "query",
+        "dcterms:description": "MCP tool arguments (query)",
+        "prov:wasGeneratedBy": {
+          "@id": "urn:civic-evidence:pkg-golden-001:inference:inf-1"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:data:ccc333",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:ccc333",
+        "dcterms:description": "Data response from Google Data Commons MCP Server",
+        "civic:sourceId": "data-commons",
+        "prov:wasGeneratedBy": {
+          "@id": "urn:civic-evidence:pkg-golden-001:tool-call:tool-2"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:tool-call:tool-2",
+        "@type": "prov:Activity",
+        "dcterms:description": "MCP tool call: get_observations (query)",
+        "civic:sourceId": "data-commons",
+        "prov:used": [
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:query:9fa0829aba3b6663a521ece5820717e7dee55c346681fa53f29b36044fe3fd35"
+          }
+        ],
+        "prov:wasAssociatedWith": {
+          "@id": "urn:civic-evidence:mcp-server:data-commons"
+        },
+        "prov:startedAtTime": {
+          "@value": "1970-01-01T00:00:05.000Z",
+          "@type": "xsd:dateTime"
+        },
+        "prov:endedAtTime": {
+          "@value": "1970-01-01T00:00:06.000Z",
+          "@type": "xsd:dateTime"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:query:1f6ca9e86ea4683e81935dc771d8e4bc7108fd9d76ed7e3e8c77b4b291b827ed",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:1f6ca9e86ea4683e81935dc771d8e4bc7108fd9d76ed7e3e8c77b4b291b827ed",
+        "civic:toolName": "ckan__aggregate_data",
+        "civic:operationType": "query",
+        "dcterms:description": "MCP tool arguments (query)",
+        "prov:wasGeneratedBy": {
+          "@id": "urn:civic-evidence:pkg-golden-001:inference:inf-1"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:data:ddd444",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:ddd444",
+        "dcterms:description": "Data response from Boston OpenContext MCP Server",
+        "civic:sourceId": "boston-opencontext",
+        "prov:wasGeneratedBy": {
+          "@id": "urn:civic-evidence:pkg-golden-001:tool-call:tool-3"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:tool-call:tool-3",
+        "@type": "prov:Activity",
+        "dcterms:description": "MCP tool call: ckan__aggregate_data (query)",
+        "civic:sourceId": "boston-opencontext",
+        "prov:used": [
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:query:1f6ca9e86ea4683e81935dc771d8e4bc7108fd9d76ed7e3e8c77b4b291b827ed"
+          }
+        ],
+        "prov:wasAssociatedWith": {
+          "@id": "urn:civic-evidence:mcp-server:boston-opencontext"
+        },
+        "prov:startedAtTime": {
+          "@value": "1970-01-01T00:00:07.000Z",
+          "@type": "xsd:dateTime"
+        },
+        "prov:endedAtTime": {
+          "@value": "1970-01-01T00:00:08.000Z",
+          "@type": "xsd:dateTime"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:query:a69fbbcf7209c6f659a75067c9fa03037c2ae23f55a6f854d5994209129bbbf6",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:a69fbbcf7209c6f659a75067c9fa03037c2ae23f55a6f854d5994209129bbbf6",
+        "civic:toolName": "mystery_tool",
+        "civic:operationType": "query",
+        "dcterms:description": "MCP tool arguments (query)",
+        "prov:wasGeneratedBy": {
+          "@id": "urn:civic-evidence:pkg-golden-001:inference:inf-1"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:data:eee555",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:eee555",
+        "dcterms:description": "Data response from euro stat",
+        "civic:sourceId": "euro stat",
+        "prov:wasGeneratedBy": {
+          "@id": "urn:civic-evidence:pkg-golden-001:tool-call:tool-4"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:tool-call:tool-4",
+        "@type": "prov:Activity",
+        "dcterms:description": "MCP tool call: mystery_tool (query)",
+        "civic:sourceId": "euro stat",
+        "prov:used": [
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:query:a69fbbcf7209c6f659a75067c9fa03037c2ae23f55a6f854d5994209129bbbf6"
+          }
+        ],
+        "prov:wasAssociatedWith": {
+          "@id": "urn:civic-evidence:mcp-server:socrata"
+        },
+        "prov:startedAtTime": {
+          "@value": "1970-01-01T00:00:09.000Z",
+          "@type": "xsd:dateTime"
+        },
+        "prov:endedAtTime": {
+          "@value": "1970-01-01T00:00:10.000Z",
+          "@type": "xsd:dateTime"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:query:650cf2c074ab50b03d3a0fefe16d7dc3ed8835af511f596aac0dfb1505adbdf0",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:650cf2c074ab50b03d3a0fefe16d7dc3ed8835af511f596aac0dfb1505adbdf0",
+        "civic:toolName": "get_data",
+        "civic:operationType": "metadata",
+        "dcterms:description": "MCP tool arguments (metadata)",
+        "prov:wasGeneratedBy": {
+          "@id": "urn:civic-evidence:pkg-golden-001:inference:inf-1"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:tool-call:tool-5",
+        "@type": "prov:Activity",
+        "dcterms:description": "MCP tool call: get_data (metadata)",
+        "civic:sourceId": "socrata",
+        "prov:used": [
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:query:650cf2c074ab50b03d3a0fefe16d7dc3ed8835af511f596aac0dfb1505adbdf0"
+          }
+        ],
+        "prov:wasAssociatedWith": {
+          "@id": "urn:civic-evidence:mcp-server:socrata"
+        },
+        "prov:startedAtTime": {
+          "@value": "1970-01-01T00:00:11.000Z",
+          "@type": "xsd:dateTime"
+        },
+        "prov:endedAtTime": {
+          "@value": "1970-01-01T00:00:12.000Z",
+          "@type": "xsd:dateTime"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:synthesis:synth-1",
+        "@type": "prov:Activity",
+        "dcterms:description": "Output synthesis",
+        "prov:wasAssociatedWith": {
+          "@id": "urn:civic-evidence:model:openai-gpt-4o"
+        },
+        "prov:startedAtTime": {
+          "@value": "1970-01-01T00:00:15.000Z",
+          "@type": "xsd:dateTime"
+        },
+        "prov:endedAtTime": {
+          "@value": "1970-01-01T00:00:16.000Z",
+          "@type": "xsd:dateTime"
+        }
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:output:123571add9bd101d35ab7e7da90b5710d0d98eb8ac494c94c3c7b1cee8aac577",
+        "@type": "prov:Entity",
+        "prov:wasGeneratedBy": {
+          "@id": "urn:civic-evidence:pkg-golden-001:synthesis:synth-1"
+        },
+        "prov:wasDerivedFrom": [
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:data:bbb222"
+          },
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:data:ccc333"
+          },
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:data:ddd444"
+          },
+          {
+            "@id": "urn:civic-evidence:pkg-golden-001:data:eee555"
+          }
+        ]
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-001:inference:inf-1",
+        "@type": "prov:Activity",
+        "prov:qualifiedAssociation": {
+          "@type": "prov:Association",
+          "prov:agent": {
+            "@id": "urn:civic-evidence:model:openai-gpt-4o"
+          },
+          "prov:hadPlan": {
+            "@id": "urn:civic-evidence:pkg-golden-001:skill:aaa111"
+          }
+        }
+      }
+    ]
+  },
+  "provenanceGraphMinimal": {
+    "@context": {
+      "prov": "http://www.w3.org/ns/prov#",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "civic": "https://civicaitools.org/ns/evidence/",
+      "dcterms": "http://purl.org/dc/terms/"
+    },
+    "@graph": [
+      {
+        "@id": "urn:civic-evidence:pkg-golden-002:prompt:ph2",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:ph2",
+        "dcterms:description": "User query prompt"
+      },
+      {
+        "@id": "urn:civic-evidence:pkg-golden-002:output:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "@type": "prov:Entity",
+        "civic:contentHash": "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        "dcterms:description": "AI-generated analysis output"
+      },
+      {
+        "@id": "urn:civic-evidence:model:anthropic-claude-3-5-sonnet",
+        "@type": [
+          "prov:Agent",
+          "prov:SoftwareAgent"
+        ],
+        "dcterms:title": "anthropic/claude-3-5-sonnet",
+        "dcterms:description": "Large language model via OpenRouter"
+      },
+      {
+        "@id": "urn:civic-evidence:platform:civic-ai-tools",
+        "@type": [
+          "prov:Agent",
+          "prov:SoftwareAgent"
+        ],
+        "dcterms:title": "Civic AI Tools",
+        "civic:url": "https://civicaitools.org"
+      }
+    ]
+  },
+  "toolCalls": [
+    {
+      "name": "get_data",
+      "args": {
+        "type": "query",
+        "portal": "data.cityofnewyork.us",
+        "dataset_id": "erm2-nwe9"
+      }
+    },
+    {
+      "name": "get_observations",
+      "args": {
+        "variable_dcid": "Count_Person"
+      }
+    },
+    {
+      "name": "ckan__aggregate_data",
+      "args": {
+        "resource_id": "abc"
+      }
+    },
+    {
+      "name": "mystery_tool",
+      "args": {
+        "q": "x"
+      }
+    },
+    {
+      "name": "get_data",
+      "args": {
+        "type": "metadata",
+        "portal": "data.cityofnewyork.us",
+        "dataset_id": "43nn-pn8j"
+      }
+    }
+  ],
+  "dataSourcesNow": "2026-08-01T00:00:00.000Z",
+  "dataSources": [
+    {
+      "sourceId": "socrata",
+      "catalogType": "socrata",
+      "portalUrl": "https://data.cityofnewyork.us",
+      "datasetId": "erm2-nwe9",
+      "datasetUrl": "https://data.cityofnewyork.us/d/erm2-nwe9",
+      "accessTimestamp": "2026-08-01T00:00:00.000Z"
+    },
+    {
+      "sourceId": "socrata",
+      "catalogType": "socrata",
+      "portalUrl": "https://data.cityofnewyork.us",
+      "datasetId": "43nn-pn8j",
+      "datasetUrl": "https://data.cityofnewyork.us/d/43nn-pn8j",
+      "accessTimestamp": "2026-08-01T00:00:00.000Z"
+    },
+    {
+      "sourceId": "data-commons",
+      "catalogType": "data-commons",
+      "portalUrl": "https://api.datacommons.org/mcp",
+      "accessTimestamp": "2026-08-01T00:00:00.000Z"
+    },
+    {
+      "sourceId": "boston-opencontext",
+      "catalogType": "ckan",
+      "portalUrl": "https://data.boston.gov",
+      "accessTimestamp": "2026-08-01T00:00:00.000Z"
+    }
+  ]
+}

--- a/packages/civic-typed-harness/src/capture/data-sources.test.ts
+++ b/packages/civic-typed-harness/src/capture/data-sources.test.ts
@@ -1,0 +1,368 @@
+// Data-source population tests: golden parity against the reference
+// implementation's output, the reference behaviors ported from the app's
+// test suite (dedupe, aggregate entries, fallbacks), and the harness
+// additions — caller-supplied resolver + registry injection.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import {
+  buildDataSources,
+  resolveToolSource,
+  type ToolCallSummary,
+} from './data-sources.ts';
+import type { CivicSourceRegistry } from '../format/sources.ts';
+
+const FIXTURE = JSON.parse(
+  readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', '__fixtures__', 'website-golden.json'),
+    'utf8',
+  ),
+);
+
+interface SpanStub {
+  name: string;
+  attributes: Array<{ key: string; value: { stringValue?: string } }>;
+}
+
+function traceWithToolSpans(spans: SpanStub[]): Record<string, unknown> {
+  return {
+    resourceSpans: [
+      {
+        scopeSpans: [{ spans }],
+      },
+    ],
+  };
+}
+
+function toolSpan(source: string, attrs: Record<string, string> = {}): SpanStub {
+  const allAttrs: Record<string, string> = { 'mcp.source': source, ...attrs };
+  return {
+    name: 'mcp_tool_call',
+    attributes: Object.entries(allAttrs).map(([key, stringValue]) => ({
+      key,
+      value: { stringValue },
+    })),
+  };
+}
+
+const NOW = '2026-04-16T00:00:00.000Z';
+
+// --- Byte parity against the reference implementation ---
+
+test('golden parity: multi-source tool calls reproduce the reference dataSources byte-for-byte', () => {
+  const entries = buildDataSources(
+    FIXTURE.toolCalls,
+    FIXTURE.trace,
+    'data.cityofnewyork.us',
+    FIXTURE.dataSourcesNow,
+  );
+  assert.equal(JSON.stringify(entries), JSON.stringify(FIXTURE.dataSources));
+});
+
+// --- Ported reference tests ---
+
+test('Socrata-only: one entry per unique dataset_id, tagged sourceId=socrata', () => {
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    },
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    }, // duplicate dataset — should be deduped
+    {
+      name: 'get_data',
+      args: { type: 'metadata', portal: 'data.cityofnewyork.us', dataset_id: '43nn-pn8j' },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('socrata', { 'tool.dataset_id': 'erm2-nwe9', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+    toolSpan('socrata', { 'tool.dataset_id': 'erm2-nwe9', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+    toolSpan('socrata', { 'tool.dataset_id': '43nn-pn8j', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 2);
+  const first = entries[0];
+  assert.equal(first.sourceId, 'socrata');
+  assert.equal(first.catalogType, 'socrata');
+  assert.equal(first.portalUrl, 'https://data.cityofnewyork.us');
+  assert.equal(first.datasetId, 'erm2-nwe9');
+  assert.equal(first.datasetUrl, 'https://data.cityofnewyork.us/d/erm2-nwe9');
+  assert.equal(first.accessTimestamp, NOW);
+  for (const entry of entries) {
+    assert.ok(entry.sourceId, `entry is missing sourceId: ${JSON.stringify(entry)}`);
+  }
+});
+
+test('Data Commons only: emits a single aggregate entry tagged sourceId=data-commons', () => {
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'search_indicators', args: { query: 'median household income' } },
+    {
+      name: 'get_observations',
+      args: { variable_dcid: 'Median_Income_Household', place_dcid: 'geoId/36061' },
+    },
+  ];
+  const trace = traceWithToolSpans([toolSpan('data-commons'), toolSpan('data-commons')]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  const entry = entries[0];
+  assert.equal(entry.sourceId, 'data-commons');
+  assert.equal(entry.catalogType, 'data-commons');
+  assert.equal(entry.portalUrl, 'https://api.datacommons.org/mcp');
+  // No per-dataset identifier for DC — the knowledge graph isn't dataset-keyed.
+  assert.equal(entry.datasetId, undefined);
+  assert.equal(entry.datasetUrl, undefined);
+});
+
+test('Multi-source: Socrata + Data Commons in one analysis produce distinct entries', () => {
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'search_indicators', args: { query: 'median household income' } },
+    {
+      name: 'get_observations',
+      args: { variable_dcid: 'Median_Income_Household', place_dcid: 'geoId/36061' },
+    },
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('data-commons'),
+    toolSpan('data-commons'),
+    toolSpan('socrata', { 'tool.dataset_id': 'erm2-nwe9', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 2);
+  const socrataEntry = entries.find((s) => s.sourceId === 'socrata');
+  const dcEntry = entries.find((s) => s.sourceId === 'data-commons');
+  assert.ok(socrataEntry, 'missing socrata dataSource entry');
+  assert.ok(dcEntry, 'missing data-commons dataSource entry');
+  assert.equal(socrataEntry!.datasetId, 'erm2-nwe9');
+  assert.equal(dcEntry!.portalUrl, 'https://api.datacommons.org/mcp');
+});
+
+test('Empty trace falls back to tool-name source mapping (Socrata)', () => {
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    },
+  ];
+  const trace = { resourceSpans: [] };
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].sourceId, 'socrata');
+  assert.equal(entries[0].datasetId, 'erm2-nwe9');
+});
+
+test('Empty trace falls back to tool-name mapping (Data Commons)', () => {
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_observations',
+      args: { variable_dcid: 'Count_Person', place_dcid: 'country/USA' },
+    },
+  ];
+  const trace = { resourceSpans: [] };
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].sourceId, 'data-commons');
+});
+
+test('Boston OpenContext only: emits a single aggregate entry with catalogType=ckan', () => {
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'ckan__search_datasets', args: { query: '311 pothole requests' } },
+    {
+      name: 'ckan__aggregate_data',
+      args: {
+        resource_id: '8048697b-ad64-4bfc-b090-ee00169f2323',
+        group_by: ['neighborhood'],
+        metrics: { count: 'count(*)' },
+      },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('boston-opencontext'),
+    toolSpan('boston-opencontext'),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  const entry = entries[0];
+  assert.equal(entry.sourceId, 'boston-opencontext');
+  assert.equal(entry.catalogType, 'ckan');
+  assert.equal(entry.portalUrl, 'https://data.boston.gov');
+  assert.equal(entry.datasetId, undefined);
+  assert.equal(entry.datasetUrl, undefined);
+  assert.equal(entry.accessTimestamp, NOW);
+});
+
+test('Three-source analysis produces three distinct entries', () => {
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'search_indicators', args: { query: 'population' } },
+    {
+      name: 'get_observations',
+      args: { variable_dcid: 'Count_Person', place_dcid: 'geoId/25025' },
+    },
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    },
+    {
+      name: 'ckan__aggregate_data',
+      args: { resource_id: 'boston-311-uuid', group_by: ['neighborhood'], metrics: { count: 'count(*)' } },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('data-commons'),
+    toolSpan('data-commons'),
+    toolSpan('socrata', { 'tool.dataset_id': 'erm2-nwe9', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+    toolSpan('boston-opencontext'),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 3);
+  const socrata = entries.find((s) => s.sourceId === 'socrata');
+  const dc = entries.find((s) => s.sourceId === 'data-commons');
+  const boston = entries.find((s) => s.sourceId === 'boston-opencontext');
+  assert.ok(socrata, 'missing socrata dataSource entry');
+  assert.ok(dc, 'missing data-commons dataSource entry');
+  assert.ok(boston, 'missing boston-opencontext dataSource entry');
+  assert.equal(socrata!.datasetId, 'erm2-nwe9');
+  assert.equal(dc!.portalUrl, 'https://api.datacommons.org/mcp');
+  assert.equal(boston!.catalogType, 'ckan');
+  assert.equal(boston!.portalUrl, 'https://data.boston.gov');
+});
+
+test('Empty trace falls back to tool-name mapping (Boston OpenContext)', () => {
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'ckan__search_datasets', args: { query: 'permits' } },
+  ];
+  const trace = { resourceSpans: [] };
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].sourceId, 'boston-opencontext');
+});
+
+test('Regression: Socrata-only entry shape is backward-compatible', () => {
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('socrata', { 'tool.dataset_id': 'erm2-nwe9', 'tool.portal_domain': 'data.cityofnewyork.us' }),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.cityofnewyork.us', NOW);
+
+  assert.equal(entries.length, 1);
+  const entry = entries[0];
+  const expectedKeys = ['sourceId', 'catalogType', 'portalUrl', 'datasetId', 'datasetUrl', 'accessTimestamp'];
+  for (const key of expectedKeys) {
+    assert.ok(key in entry, `Socrata entry missing expected key: ${key}`);
+  }
+});
+
+test('Trace span mcp.source wins over tool-name mapping when they disagree', () => {
+  const tc: ToolCallSummary = {
+    name: 'get_data',
+    args: { type: 'query', portal: 'data.cityofnewyork.us', dataset_id: 'erm2-nwe9' },
+  };
+  const span = toolSpan('data-commons');
+  assert.equal(resolveToolSource(tc, span), 'data-commons');
+});
+
+test('Unknown tool with no trace span defaults to socrata (pre-M9.1 backward compat)', () => {
+  const tc: ToolCallSummary = { name: 'mystery_tool', args: {} };
+  assert.equal(resolveToolSource(tc, undefined), 'socrata');
+});
+
+// --- Harness additions: caller-supplied resolver + registry injection ---
+
+test('caller-supplied resolver overrides the civic default map', () => {
+  const tc: ToolCallSummary = { name: 'warehouse_query', args: {} };
+  const resolver = (name: string) => (name === 'warehouse_query' ? 'data-commons' : undefined);
+  assert.equal(resolveToolSource(tc, undefined, resolver), 'data-commons');
+  // Same resolver flows through buildDataSources.
+  const entries = buildDataSources(
+    [tc],
+    { resourceSpans: [] },
+    'data.cityofnewyork.us',
+    NOW,
+    { resolver },
+  );
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].sourceId, 'data-commons');
+});
+
+test('caller-supplied fallbackSourceId replaces the socrata default', () => {
+  const tc: ToolCallSummary = { name: 'mystery_tool', args: {} };
+  assert.equal(resolveToolSource(tc, undefined, () => undefined, 'data-commons'), 'data-commons');
+});
+
+test('caller-supplied registry drives catalog types, endpoints, and the aggregate split', () => {
+  const registry: CivicSourceRegistry = {
+    'city-warehouse': {
+      displayName: 'City Warehouse',
+      agentTitle: 'City Warehouse MCP Server',
+      serverUrl: 'https://mcp.city.example',
+      catalogType: 'warehouse',
+      aggregatePortalUrl: 'https://data.city.example',
+    },
+    'city-socrata': {
+      displayName: 'City Socrata',
+      agentTitle: 'City Socrata MCP Server',
+      serverUrl: 'https://socrata-mcp.city.example',
+      catalogType: 'socrata',
+    },
+  };
+  const resolver = (name: string) =>
+    name === 'warehouse_query' ? 'city-warehouse' : name === 'get_data' ? 'city-socrata' : undefined;
+  const entries = buildDataSources(
+    [
+      { name: 'warehouse_query', args: {} },
+      { name: 'get_data', args: { dataset_id: 'abcd-1234', portal: 'data.city.example' } },
+    ],
+    { resourceSpans: [] },
+    'data.city.example',
+    NOW,
+    { resolver, registry, fallbackSourceId: 'city-warehouse' },
+  );
+  assert.equal(entries.length, 2);
+  const agg = entries.find((e) => e.sourceId === 'city-warehouse');
+  const ds = entries.find((e) => e.sourceId === 'city-socrata');
+  assert.ok(agg && ds);
+  assert.equal(agg!.catalogType, 'warehouse');
+  assert.equal(agg!.portalUrl, 'https://data.city.example');
+  assert.equal(ds!.datasetUrl, 'https://data.city.example/d/abcd-1234');
+});
+
+test('unknown source ids contribute no dataSources entry', () => {
+  const trace = traceWithToolSpans([toolSpan('eurostat')]);
+  const entries = buildDataSources(
+    [{ name: 'unknown_tool', args: {} }],
+    trace,
+    'data.cityofnewyork.us',
+    NOW,
+  );
+  assert.equal(entries.length, 0);
+});

--- a/packages/civic-typed-harness/src/capture/data-sources.ts
+++ b/packages/civic-typed-harness/src/capture/data-sources.ts
@@ -1,0 +1,168 @@
+// Data-source population (CAPTURE group) — walks the trace's `mcp_tool_call`
+// spans plus the caller-supplied tool-call summary to produce one
+// `dataSources` entry per (source, datasetId) tuple. Relocated from
+// civic-ai-tools-website `src/lib/evidence/data-sources.ts:78–185` per the S2
+// brief §1, with two changes:
+//   - The tool-name → source-id resolver is a CALLER-SUPPLIED input (the
+//     app's MCP registry stays app-side); `civicToolSourceResolver` is the
+//     exported civic default.
+//   - The per-source coordinates (catalog types, endpoints) come from the
+//     format-extension group's source registry instead of module constants —
+//     which sources are dataset-keyed vs aggregate is registry-driven.
+//
+// `DataSourceEntry` is produce-core's envelope input shape — the harness
+// populates it, never redefines it.
+
+import type { DataSourceEntry } from '@typedstandards/produce-core';
+import {
+  CIVIC_SOURCE_REGISTRY,
+  FALLBACK_SOURCE_ID,
+  civicToolSourceResolver,
+  isDatasetKeyedSource,
+  type CivicSourceRegistry,
+  type ToolSourceResolver,
+} from '../format/sources.ts';
+
+export type { DataSourceEntry };
+
+/** The caller-supplied per-tool-call summary the population walks alongside
+ *  the trace. */
+export interface ToolCallSummary {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+interface TraceSpan {
+  name: string;
+  attributes?: Array<{ key: string; value?: { stringValue?: string; intValue?: string; boolValue?: boolean } }>;
+}
+
+function getToolSpans(trace: Record<string, unknown>): TraceSpan[] {
+  try {
+    // Untyped walk over the caller's trace shape.
+    const spans = (trace as any)?.resourceSpans?.[0]?.scopeSpans?.[0]?.spans;
+    if (!Array.isArray(spans)) return [];
+    return (spans as TraceSpan[]).filter((s) => s.name === 'mcp_tool_call');
+  } catch {
+    return [];
+  }
+}
+
+function spanAttr(span: TraceSpan | undefined, key: string): string | undefined {
+  if (!span) return undefined;
+  const attr = span.attributes?.find((a) => a.key === key);
+  return attr?.value?.stringValue ?? attr?.value?.intValue ?? undefined;
+}
+
+/** Optional knobs for `resolveToolSource` / `buildDataSources`. Defaults are
+ *  the civic demo values. */
+export interface DataSourceOptions {
+  /** Tool-name → source-id resolver (fallback when a span carries no
+   *  `mcp.source` attribute). Default: the civic map. */
+  resolver?: ToolSourceResolver;
+  /** Source registry driving catalog types, endpoints, and the
+   *  dataset-keyed vs aggregate split. Default: the civic registry. */
+  registry?: CivicSourceRegistry;
+  /** Source id for calls neither the trace nor the resolver can identify.
+   *  Default `socrata` (pre-M9.1 packages predate source tagging). */
+  fallbackSourceId?: string;
+}
+
+/**
+ * Resolve the MCP source for a tool call. Prefers the `mcp.source` attribute
+ * recorded on the matching `mcp_tool_call` span (the trace is the source of
+ * truth); falls back to the resolver's static mapping for packages written
+ * before source tagging or callers that ship an empty trace.
+ *
+ * Tool calls are paired to spans by index — the reference capture emits one
+ * span per call in order, so positional matching is exact in the normal
+ * flow. When the counts diverge, the static resolver still identifies the
+ * source.
+ */
+export function resolveToolSource(
+  toolCall: ToolCallSummary,
+  span: TraceSpan | undefined,
+  resolver: ToolSourceResolver = civicToolSourceResolver,
+  fallbackSourceId: string = FALLBACK_SOURCE_ID,
+): string {
+  return spanAttr(span, 'mcp.source')
+    ?? resolver(toolCall.name)
+    ?? fallbackSourceId;
+}
+
+/**
+ * Build the per-source evidence-package `dataSources` array.
+ *
+ * Dataset-keyed sources (Socrata) contribute one entry per unique
+ * `dataset_id` observed across tool calls. Aggregate sources (Data Commons,
+ * Boston OpenContext — registry entries carrying `aggregatePortalUrl`)
+ * contribute a single entry when any of their tool calls was made. Unknown
+ * source ids contribute no entry. Each entry is tagged with `sourceId` so
+ * downstream consumers can distinguish provenance. Emission order: the
+ * dataset-keyed entries (first-seen order), then aggregate sources in
+ * registry insertion order — matching the reference implementation.
+ */
+export function buildDataSources(
+  toolCalls: ToolCallSummary[],
+  trace: Record<string, unknown>,
+  fallbackPortal: string,
+  now: string,
+  options: DataSourceOptions = {},
+): DataSourceEntry[] {
+  const resolver = options.resolver ?? civicToolSourceResolver;
+  const registry = options.registry ?? CIVIC_SOURCE_REGISTRY;
+  const fallbackSourceId = options.fallbackSourceId ?? FALLBACK_SOURCE_ID;
+
+  const toolSpans = getToolSpans(trace);
+  const datasetKeyed = new Map<string, Map<string, { portalUrl: string; datasetId: string }>>();
+  const aggregateAccessed = new Set<string>();
+
+  for (let i = 0; i < toolCalls.length; i++) {
+    const tc = toolCalls[i];
+    const source = resolveToolSource(tc, toolSpans[i], resolver, fallbackSourceId);
+    if (isDatasetKeyedSource(source, registry)) {
+      const datasetId = tc.args.dataset_id as string | undefined;
+      const portal = (tc.args.portal as string) || fallbackPortal;
+      if (datasetId) {
+        let byDataset = datasetKeyed.get(source);
+        if (!byDataset) {
+          byDataset = new Map();
+          datasetKeyed.set(source, byDataset);
+        }
+        if (!byDataset.has(datasetId)) {
+          byDataset.set(datasetId, { portalUrl: `https://${portal}`, datasetId });
+        }
+      }
+    } else if (registry[source]?.aggregatePortalUrl !== undefined) {
+      aggregateAccessed.add(source);
+    }
+    // Unknown sources contribute no dataSources entry (their provenance is
+    // still visible on the PROV-O graph's tool-call activities).
+  }
+
+  const entries: DataSourceEntry[] = [];
+  for (const [sourceId, info] of Object.entries(registry)) {
+    if (info.aggregatePortalUrl === undefined) {
+      const byDataset = datasetKeyed.get(sourceId);
+      if (!byDataset) continue;
+      for (const { portalUrl, datasetId } of byDataset.values()) {
+        entries.push({
+          sourceId,
+          catalogType: info.catalogType,
+          portalUrl,
+          datasetId,
+          datasetUrl: `${portalUrl}/d/${datasetId}`,
+          accessTimestamp: now,
+        });
+      }
+    } else if (aggregateAccessed.has(sourceId)) {
+      entries.push({
+        sourceId,
+        catalogType: info.catalogType,
+        portalUrl: info.aggregatePortalUrl,
+        accessTimestamp: now,
+      });
+    }
+  }
+  return entries;
+}

--- a/packages/civic-typed-harness/src/capture/provenance.test.ts
+++ b/packages/civic-typed-harness/src/capture/provenance.test.ts
@@ -1,0 +1,272 @@
+// Provenance-builder tests: (1) byte parity against golden output captured
+// from the reference implementation (civic-ai-tools-website
+// src/lib/evidence/provenance.ts, 2026-08-01) — the port must reproduce the
+// reference graph BYTE-FOR-BYTE with the demo default config, because the
+// legacy envelope chain hashes JSON.stringify output; (2) the M9.3
+// agent-pruning behavior ported from the reference test suite; (3) config
+// injection — the platform agent, source registry, and model description are
+// per-instance inputs.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { buildProvenanceGraph, type ProvenanceConfig } from './provenance.ts';
+
+const FIXTURE = JSON.parse(
+  readFileSync(
+    join(dirname(fileURLToPath(import.meta.url)), '..', '__fixtures__', 'website-golden.json'),
+    'utf8',
+  ),
+);
+
+// --- Byte parity against the reference implementation ---
+
+test('golden parity: multi-source trace reproduces the reference graph byte-for-byte', () => {
+  const graph = buildProvenanceGraph(FIXTURE.trace, FIXTURE.provenanceInput);
+  assert.equal(
+    JSON.stringify(graph),
+    JSON.stringify(FIXTURE.provenanceGraph),
+    'harness graph must be byte-identical to the reference implementation output',
+  );
+});
+
+test('golden parity: empty trace + pre-computed outputHash reproduces the reference minimal graph', () => {
+  const graph = buildProvenanceGraph(
+    { resourceSpans: [] },
+    {
+      packageId: 'pkg-golden-002',
+      promptHash: 'ph2',
+      outputHash: 'deadbeef'.repeat(8),
+      model: 'anthropic/claude-3-5-sonnet',
+      portal: 'data.cityofnewyork.us',
+    },
+  );
+  assert.equal(JSON.stringify(graph), JSON.stringify(FIXTURE.provenanceGraphMinimal));
+});
+
+// --- Ported reference tests: M9.3 agent pruning ---
+
+interface SpanStub {
+  name: string;
+  spanId?: string;
+  startTimeUnixNano?: string;
+  endTimeUnixNano?: string;
+  attributes: Array<{ key: string; value: { stringValue?: string; intValue?: string } }>;
+}
+
+function traceOf(spans: SpanStub[]): Record<string, unknown> {
+  return {
+    resourceSpans: [
+      {
+        scopeSpans: [{ spans }],
+      },
+    ],
+  };
+}
+
+function attrs(map: Record<string, string>): SpanStub['attributes'] {
+  return Object.entries(map).map(([key, stringValue]) => ({ key, value: { stringValue } }));
+}
+
+function skillSpan(hash: string): SpanStub {
+  return {
+    name: 'skill_fetch',
+    attributes: attrs({
+      'skill.text_hash': hash,
+      'skill.mcp_server_url': 'https://socrata-mcp.civicaitools.org',
+    }),
+  };
+}
+
+// Fixture convention: synthetic span timestamps stay under 13 digits
+// (seconds-scale nano values) so they cannot pattern-match as card/account
+// numbers in pre-push sensitivity scans.
+function toolSpan(source: string, toolName: string, spanId: string): SpanStub {
+  return {
+    name: 'mcp_tool_call',
+    spanId,
+    startTimeUnixNano: '1000000000',
+    endTimeUnixNano: '2000000000',
+    attributes: attrs({
+      'mcp.source': source,
+      'tool.name': toolName,
+      'tool.operation_type': 'query',
+      'tool.arguments': '{}',
+    }),
+  };
+}
+
+const BASE_INPUT = {
+  packageId: 'pkg-123',
+  promptHash: 'abc123',
+  outputText: 'hello world',
+  model: 'openai/gpt-4o',
+  portal: 'data.cityofnewyork.us',
+};
+
+function mcpAgents(graph: Array<{ '@id': string; [k: string]: unknown }>): string[] {
+  return graph
+    .filter((node) => typeof node['@id'] === 'string' && node['@id'].startsWith('urn:civic-evidence:mcp-server:'))
+    .map((node) => node['@id'] as string);
+}
+
+test('Data-Commons-only analysis emits only the data-commons MCP agent', () => {
+  const trace = traceOf([skillSpan('skill-hash'), toolSpan('data-commons', 'get_observations', 'span-1')]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  assert.deepEqual(mcpAgents(graph['@graph']), ['urn:civic-evidence:mcp-server:data-commons']);
+});
+
+test('Socrata-only analysis emits only the socrata MCP agent', () => {
+  const trace = traceOf([skillSpan('skill-hash'), toolSpan('socrata', 'get_data', 'span-1')]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  assert.deepEqual(mcpAgents(graph['@graph']), ['urn:civic-evidence:mcp-server:socrata']);
+});
+
+test('Multi-source analysis emits both MCP agents', () => {
+  const trace = traceOf([
+    skillSpan('skill-hash'),
+    toolSpan('socrata', 'get_data', 'span-1'),
+    toolSpan('data-commons', 'get_observations', 'span-2'),
+  ]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const agents = mcpAgents(graph['@graph']);
+  assert.equal(agents.length, 2);
+  assert.ok(agents.includes('urn:civic-evidence:mcp-server:socrata'));
+  assert.ok(agents.includes('urn:civic-evidence:mcp-server:data-commons'));
+});
+
+test('Boston OpenContext only analysis emits only the boston-opencontext MCP agent with correct title', () => {
+  const trace = traceOf([skillSpan('skill-hash'), toolSpan('boston-opencontext', 'ckan__search_datasets', 'span-1')]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  assert.deepEqual(mcpAgents(graph['@graph']), ['urn:civic-evidence:mcp-server:boston-opencontext']);
+
+  const bostonAgentNode = graph['@graph'].find(
+    (n) => n['@id'] === 'urn:civic-evidence:mcp-server:boston-opencontext',
+  );
+  assert.ok(bostonAgentNode, 'expected Boston OpenContext agent node in graph');
+  assert.equal(bostonAgentNode!['dcterms:title'], 'Boston OpenContext MCP Server');
+  assert.equal(bostonAgentNode!['civic:serverUrl'], 'https://data-mcp.boston.gov/mcp');
+  assert.equal(bostonAgentNode!['civic:sourceId'], 'boston-opencontext');
+});
+
+test('Three-source analysis emits all three MCP agents, no stray sources', () => {
+  const trace = traceOf([
+    skillSpan('skill-hash'),
+    toolSpan('socrata', 'get_data', 'span-1'),
+    toolSpan('data-commons', 'get_observations', 'span-2'),
+    toolSpan('boston-opencontext', 'ckan__aggregate_data', 'span-3'),
+  ]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  const agents = mcpAgents(graph['@graph']);
+  assert.equal(agents.length, 3);
+  assert.ok(agents.includes('urn:civic-evidence:mcp-server:socrata'));
+  assert.ok(agents.includes('urn:civic-evidence:mcp-server:data-commons'));
+  assert.ok(agents.includes('urn:civic-evidence:mcp-server:boston-opencontext'));
+});
+
+test('Skill fetched but no tool calls emits no MCP agent', () => {
+  const trace = traceOf([skillSpan('skill-hash')]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  assert.deepEqual(mcpAgents(graph['@graph']), []);
+});
+
+test('Pre-M9.1 Socrata span without mcp.source attribute still emits the socrata agent', () => {
+  const legacyToolSpan: SpanStub = {
+    name: 'mcp_tool_call',
+    spanId: 'legacy-1',
+    startTimeUnixNano: '1000000000',
+    endTimeUnixNano: '2000000000',
+    attributes: attrs({
+      'tool.name': 'get_data',
+      'tool.operation_type': 'query',
+      'tool.arguments': '{}',
+    }),
+  };
+  const trace = traceOf([skillSpan('skill-hash'), legacyToolSpan]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT);
+  assert.deepEqual(mcpAgents(graph['@graph']), ['urn:civic-evidence:mcp-server:socrata']);
+});
+
+// --- Config injection (config-not-constants) ---
+
+const CUSTOM_CONFIG: ProvenanceConfig = {
+  platformAgent: {
+    id: 'city-evidence-portal',
+    title: 'City Evidence Portal',
+    url: 'https://evidence.city.example',
+  },
+  sourceRegistry: {
+    'city-warehouse': {
+      displayName: 'City Warehouse',
+      agentTitle: 'City Warehouse MCP Server',
+      serverUrl: 'https://mcp.city.example',
+      catalogType: 'warehouse',
+      aggregatePortalUrl: 'https://data.city.example',
+    },
+  },
+  fallbackSourceId: 'city-warehouse',
+  skillSourceId: 'city-warehouse',
+  modelAgentDescription: 'Large language model via a self-hosted gateway',
+};
+
+test('config injection: platform agent identity is a config input', () => {
+  const graph = buildProvenanceGraph(traceOf([]), BASE_INPUT, CUSTOM_CONFIG);
+  const platform = graph['@graph'].find((n) =>
+    n['@id'].startsWith('urn:civic-evidence:platform:'),
+  );
+  assert.ok(platform);
+  assert.equal(platform!['@id'], 'urn:civic-evidence:platform:city-evidence-portal');
+  assert.equal(platform!['dcterms:title'], 'City Evidence Portal');
+  assert.equal(platform!['civic:url'], 'https://evidence.city.example');
+  // The demo platform identity must NOT leak into a custom-config graph.
+  assert.ok(!JSON.stringify(graph).includes('urn:civic-evidence:platform:civic-ai-tools'));
+});
+
+test('config injection: source registry and fallback source are config inputs', () => {
+  const trace = traceOf([toolSpan('city-warehouse', 'warehouse_query', 'span-1')]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT, CUSTOM_CONFIG);
+  const agent = graph['@graph'].find(
+    (n) => n['@id'] === 'urn:civic-evidence:mcp-server:city-warehouse',
+  );
+  assert.ok(agent, 'custom source agent should be emitted');
+  assert.equal(agent!['dcterms:title'], 'City Warehouse MCP Server');
+  assert.equal(agent!['civic:serverUrl'], 'https://mcp.city.example');
+});
+
+test('config injection: skill-fetch server URL overrides the configured skill source', () => {
+  const trace = traceOf([
+    {
+      name: 'skill_fetch',
+      attributes: attrs({
+        'skill.text_hash': 'sh',
+        'skill.mcp_server_url': 'https://mcp-preview.city.example',
+      }),
+    },
+    toolSpan('city-warehouse', 'warehouse_query', 'span-1'),
+  ]);
+  const graph = buildProvenanceGraph(trace, BASE_INPUT, CUSTOM_CONFIG);
+  const agent = graph['@graph'].find(
+    (n) => n['@id'] === 'urn:civic-evidence:mcp-server:city-warehouse',
+  );
+  assert.equal(agent!['civic:serverUrl'], 'https://mcp-preview.city.example');
+});
+
+test('config injection: model agent description is a config input', () => {
+  const graph = buildProvenanceGraph(traceOf([]), BASE_INPUT, CUSTOM_CONFIG);
+  const model = graph['@graph'].find((n) => n['@id'].startsWith('urn:civic-evidence:model:'));
+  assert.equal(model!['dcterms:description'], 'Large language model via a self-hosted gateway');
+});
+
+test('default config: demo platform agent and OpenRouter description are the defaults', () => {
+  const graph = buildProvenanceGraph(traceOf([]), BASE_INPUT);
+  const platform = graph['@graph'].find(
+    (n) => n['@id'] === 'urn:civic-evidence:platform:civic-ai-tools',
+  );
+  assert.ok(platform);
+  assert.equal(platform!['dcterms:title'], 'Civic AI Tools');
+  assert.equal(platform!['civic:url'], 'https://civicaitools.org');
+  const model = graph['@graph'].find((n) => n['@id'].startsWith('urn:civic-evidence:model:'));
+  assert.equal(model!['dcterms:description'], 'Large language model via OpenRouter');
+});

--- a/packages/civic-typed-harness/src/capture/provenance.ts
+++ b/packages/civic-typed-harness/src/capture/provenance.ts
@@ -1,0 +1,449 @@
+// Civic provenance builder (CAPTURE group) — walks an OTel trace and maps the
+// analysis pipeline (LLM inference, MCP tool calls, data responses) to a
+// W3C PROV-O JSON-LD graph. Relocated whole from civic-ai-tools-website
+// `src/lib/evidence/provenance.ts:65–392` per the S2 brief §1, rebuilt on
+// @typedstandards/produce-core's generic ProvGraph/ProvNode types and
+// node/edge helpers. Every `civic:` term, urn scheme, and agent coordinate is
+// imported from the format-extension group — this module WALKS, it does not
+// define vocabulary (the package's internal module boundary).
+//
+// Config-not-constants: the platform-agent identity, the source-agent
+// registry (server URLs), and the model-agent description are typed config
+// inputs; `CIVICAITOOLS_PROVENANCE_CONFIG` is the demo default and
+// reproduces the reference implementation's output byte-for-byte (property
+// insertion order is preserved throughout — the legacy hash chain's byte
+// contract).
+
+import {
+  makeProvGraph,
+  makeEntityNode,
+  makeActivityNode,
+  makeAgentNode,
+  provRef,
+  provUsed,
+  provWasGeneratedBy,
+  provWasDerivedFrom,
+  provWasAssociatedWith,
+  xsdDateTime,
+  type ProvGraph,
+  type ProvNode,
+  type ProvNodeRef,
+} from '@typedstandards/produce-core';
+import { hash } from './trace.ts';
+import type { OTelTrace, OTelAttribute } from './trace.ts';
+import {
+  makeCivicProvContext,
+  civicUrn,
+  civicModelUrn,
+  civicSourceAgentUrn,
+  civicPlatformUrn,
+  CIVICAITOOLS_PLATFORM_AGENT,
+  type PlatformAgentConfig,
+} from '../format/vocabulary.ts';
+import {
+  CIVIC_SOURCE_REGISTRY,
+  FALLBACK_SOURCE_ID,
+  isDatasetKeyedSource,
+  type CivicSourceRegistry,
+} from '../format/sources.ts';
+
+export type { ProvGraph, ProvNode };
+
+/** Package-level inputs to the graph build. */
+export interface ProvenanceInput {
+  packageId: string;
+  promptHash: string;
+  promptText?: string;
+  /** Inline output text. Used to derive the output hash unless
+   *  `outputHash` is supplied explicitly. */
+  outputText?: string;
+  /** Pre-computed SHA-256 hex of the output. Supplied when the output is
+   *  stored as a BlobRef and inline text isn't available; the ref hash
+   *  itself is exactly this value by construction. */
+  outputHash?: string;
+  model: string;
+  portal: string;
+}
+
+/** Instance configuration for the graph build (config-not-constants). */
+export interface ProvenanceConfig {
+  /** Platform-agent identity — the deployment publishing the evidence. */
+  platformAgent: PlatformAgentConfig;
+  /** Source registry supplying agent titles and MCP server URLs. */
+  sourceRegistry: CivicSourceRegistry;
+  /** Source id untagged tool spans fall back to. Default `socrata`
+   *  (pre-source-tagging captures were Socrata-only). */
+  fallbackSourceId?: string;
+  /** Source whose agent `civic:serverUrl` the trace's skill-fetch span URL
+   *  overrides when present (the skill is fetched from that source's MCP
+   *  server). Default `socrata`. */
+  skillSourceId?: string;
+  /** `dcterms:description` of the model agent. Default names the demo
+   *  deployment's model gateway. */
+  modelAgentDescription?: string;
+}
+
+/** Demo default: the civicaitools.org reference deployment. */
+export const CIVICAITOOLS_PROVENANCE_CONFIG: ProvenanceConfig = {
+  platformAgent: CIVICAITOOLS_PLATFORM_AGENT,
+  sourceRegistry: CIVIC_SOURCE_REGISTRY,
+};
+
+const DEFAULT_MODEL_AGENT_DESCRIPTION = 'Large language model via OpenRouter';
+
+// --- Helpers ---
+
+function getAttr(attrs: OTelAttribute[], key: string): string | undefined {
+  const attr = attrs.find(a => a.key === key);
+  return attr?.value?.stringValue ?? attr?.value?.intValue ?? undefined;
+}
+
+function nanoToIso(nano: string): string {
+  const ms = Math.floor(Number(nano) / 1_000_000);
+  return new Date(ms).toISOString();
+}
+
+// --- Builder ---
+
+/**
+ * Build a W3C PROV-O JSON-LD graph from an OTel trace and package metadata.
+ *
+ * Walks the trace spans and maps them to PROV concepts:
+ * - LLM inference spans → prov:Activity
+ * - MCP tool call spans → prov:Activity
+ * - Prompt, skill guidance, data responses, output → prov:Entity
+ * - LLM model, MCP server, platform → prov:Agent
+ */
+export function buildProvenanceGraph(
+  trace: Record<string, unknown>,
+  input: ProvenanceInput,
+  config: ProvenanceConfig = CIVICAITOOLS_PROVENANCE_CONFIG,
+): ProvGraph {
+  const otel = trace as unknown as OTelTrace;
+  const spans = otel?.resourceSpans?.[0]?.scopeSpans?.[0]?.spans || [];
+  const { packageId, promptHash, promptText, outputText, model, portal } = input;
+  const outputHash = input.outputHash ?? hash(outputText ?? '');
+
+  const registry = config.sourceRegistry;
+  const fallbackSourceId = config.fallbackSourceId ?? FALLBACK_SOURCE_ID;
+  const skillSourceId = config.skillSourceId ?? FALLBACK_SOURCE_ID;
+  const modelDescription =
+    config.modelAgentDescription ?? DEFAULT_MODEL_AGENT_DESCRIPTION;
+
+  const graph: ProvNode[] = [];
+
+  // --- Entities ---
+
+  // User prompt
+  graph.push(
+    makeEntityNode(civicUrn(packageId, 'prompt', promptHash), {
+      'civic:contentHash': `sha256:${promptHash}`,
+      'dcterms:description': 'User query prompt',
+      ...(promptText ? { 'prov:value': promptText } : {}),
+    }),
+  );
+
+  // Skill guidance (from skill_fetch span). The skill is a composition of
+  // per-source guidance, so the description is source-neutral. Per-source
+  // tool agents are emitted from the tool spans below based on which sources
+  // were actually invoked.
+  const skillSpan = spans.find(s => s.name === 'skill_fetch');
+  const skillHash = skillSpan ? getAttr(skillSpan.attributes, 'skill.text_hash') : undefined;
+  const skillServerUrl = skillSpan ? getAttr(skillSpan.attributes, 'skill.mcp_server_url') : undefined;
+
+  if (skillHash) {
+    graph.push(
+      makeEntityNode(
+        civicUrn(packageId, 'skill', skillHash),
+        {
+          'civic:contentHash': `sha256:${skillHash}`,
+          'dcterms:description': 'Composed MCP skill guidance (system prompt)',
+        },
+        ['prov:Plan'],
+      ),
+    );
+  }
+
+  // Final output
+  graph.push(
+    makeEntityNode(civicUrn(packageId, 'output', outputHash), {
+      'civic:contentHash': `sha256:${outputHash}`,
+      'dcterms:description': 'AI-generated analysis output',
+    }),
+  );
+
+  // --- Agents ---
+
+  // LLM model
+  const modelUrn = civicModelUrn(model);
+  graph.push(
+    makeAgentNode(
+      modelUrn,
+      {
+        'dcterms:title': model,
+        'dcterms:description': modelDescription,
+      },
+      ['prov:SoftwareAgent'],
+    ),
+  );
+
+  // MCP server agents — one per distinct data source that appears in the
+  // trace. Tool spans carry `mcp.source`; evidence records captured before
+  // source tagging have no source attribute, so they fall back to the
+  // configured fallback source (socrata — the only source at the time) for
+  // backwards compatibility. Agent coordinates come from the source registry;
+  // the skill-fetch span URL overrides the skill source's server URL.
+  const toolSpans = spans.filter(s => s.name === 'mcp_tool_call');
+  const sourceAgentMap: Record<string, { urn: string; title: string; serverUrl: string }> = {};
+  for (const [id, info] of Object.entries(registry)) {
+    sourceAgentMap[id] = {
+      urn: civicSourceAgentUrn(id),
+      title: info.agentTitle,
+      serverUrl:
+        id === skillSourceId ? skillServerUrl || info.serverUrl : info.serverUrl,
+    };
+  }
+
+  const sourcesInTrace = new Set<string>();
+  for (const span of toolSpans) {
+    const source = getAttr(span.attributes, 'mcp.source') || fallbackSourceId;
+    sourcesInTrace.add(source);
+  }
+
+  for (const sourceId of sourcesInTrace) {
+    const meta = sourceAgentMap[sourceId] ?? {
+      urn: civicSourceAgentUrn(encodeURIComponent(sourceId)),
+      title: `${sourceId} MCP Server`,
+      serverUrl: sourceId,
+    };
+    graph.push(
+      makeAgentNode(
+        meta.urn,
+        {
+          'dcterms:title': meta.title,
+          'civic:serverUrl': meta.serverUrl,
+          'civic:sourceId': sourceId,
+        },
+        ['prov:SoftwareAgent'],
+      ),
+    );
+  }
+
+  // Resolve a source id to its agent URN, falling back to the configured
+  // fallback source for records that never tagged the span. (Reference
+  // behavior preserved: unknown ids resolve to the fallback source's agent.)
+  function agentUrnForSource(sourceId: string | undefined): string {
+    const id = sourceId || fallbackSourceId;
+    return (
+      sourceAgentMap[id]?.urn
+      ?? sourceAgentMap[fallbackSourceId]?.urn
+      ?? civicSourceAgentUrn(encodeURIComponent(id))
+    );
+  }
+
+  // Platform
+  graph.push(
+    makeAgentNode(
+      civicPlatformUrn(config.platformAgent.id),
+      {
+        'dcterms:title': config.platformAgent.title,
+        'civic:url': config.platformAgent.url,
+      },
+      ['prov:SoftwareAgent'],
+    ),
+  );
+
+  // --- Activities ---
+
+  // LLM inference spans
+  const inferenceSpans = spans.filter(s => s.name === 'llm_inference');
+  const inferenceUrns: string[] = [];
+
+  for (const span of inferenceSpans) {
+    const spanUrn = civicUrn(packageId, 'inference', span.spanId);
+    inferenceUrns.push(spanUrn);
+
+    const used: ProvNodeRef[] = [provRef(civicUrn(packageId, 'prompt', promptHash))];
+    if (skillHash) {
+      used.push(provRef(civicUrn(packageId, 'skill', skillHash)));
+    }
+
+    const promptTokens = getAttr(span.attributes, 'gen_ai.response.prompt_tokens');
+    const completionTokens = getAttr(span.attributes, 'gen_ai.response.completion_tokens');
+
+    graph.push(
+      makeActivityNode(spanUrn, {
+        'dcterms:description': `LLM inference call (iteration ${getAttr(span.attributes, 'gen_ai.inference_index') || '0'})`,
+        ...provWasAssociatedWith(modelUrn),
+        'prov:used': used,
+        ...(span.startTimeUnixNano
+          ? { 'prov:startedAtTime': xsdDateTime(nanoToIso(span.startTimeUnixNano)) }
+          : {}),
+        ...(span.endTimeUnixNano
+          ? { 'prov:endedAtTime': xsdDateTime(nanoToIso(span.endTimeUnixNano)) }
+          : {}),
+        ...(promptTokens ? { 'civic:promptTokens': Number(promptTokens) } : {}),
+        ...(completionTokens ? { 'civic:completionTokens': Number(completionTokens) } : {}),
+      }),
+    );
+  }
+
+  // MCP tool call spans
+  const dataResponseUrns: string[] = [];
+
+  for (const span of toolSpans) {
+    const toolCallUrn = civicUrn(packageId, 'tool-call', span.spanId);
+    const argsStr = getAttr(span.attributes, 'tool.arguments') || '{}';
+    const queryHash = hash(argsStr);
+    const responseHash = getAttr(span.attributes, 'tool.response_hash');
+    const toolName = getAttr(span.attributes, 'tool.name') || 'get_data';
+    const opType = getAttr(span.attributes, 'tool.operation_type') || 'unknown';
+    const datasetId = getAttr(span.attributes, 'tool.dataset_id');
+    const portalDomain = getAttr(span.attributes, 'tool.portal_domain') || portal;
+    const toolSource = getAttr(span.attributes, 'mcp.source') || fallbackSourceId;
+    const toolAgentUrn = agentUrnForSource(toolSource);
+    const toolSourceDatasetKeyed = isDatasetKeyedSource(toolSource, registry);
+
+    // Query entity (tool arguments). Find the most recent inference span
+    // before this tool call to link as generator.
+    const toolStart = Number(span.startTimeUnixNano);
+    const precedingInference = inferenceSpans
+      .filter(is => Number(is.endTimeUnixNano || '0') <= toolStart)
+      .sort((a, b) => Number(b.endTimeUnixNano || '0') - Number(a.endTimeUnixNano || '0'))[0];
+
+    const queryUrn = civicUrn(packageId, 'query', queryHash);
+    graph.push(
+      makeEntityNode(queryUrn, {
+        'civic:contentHash': `sha256:${queryHash}`,
+        'civic:toolName': toolName,
+        'civic:operationType': opType,
+        'dcterms:description': `MCP tool arguments (${opType})`,
+        ...(precedingInference
+          ? provWasGeneratedBy(civicUrn(packageId, 'inference', precedingInference.spanId))
+          : {}),
+      }),
+    );
+
+    // Data response entity
+    if (responseHash) {
+      const dataUrn = civicUrn(packageId, 'data', responseHash);
+      dataResponseUrns.push(dataUrn);
+
+      // Description varies by source — dataset-keyed sources (Socrata) have
+      // a portal domain; aggregate/unknown sources are described by their
+      // agent title.
+      const description = toolSourceDatasetKeyed
+        ? `Data response from ${portalDomain}`
+        : `Data response from ${sourceAgentMap[toolSource]?.title || toolSource}`;
+
+      const responseRows = getAttr(span.attributes, 'tool.response_rows');
+
+      graph.push(
+        makeEntityNode(dataUrn, {
+          'civic:contentHash': `sha256:${responseHash}`,
+          'dcterms:description': description,
+          'civic:sourceId': toolSource,
+          ...provWasGeneratedBy(toolCallUrn),
+          // Croissant 1.1 placeholder — only meaningful for dataset-keyed
+          // sources today.
+          ...(toolSourceDatasetKeyed && datasetId
+            ? {
+                'civic:datasetId': datasetId,
+                'civic:portalDomain': portalDomain,
+                'civic:datasetUrl': `https://${portalDomain}/d/${datasetId}`,
+                'civic:croissantMetadataUrl': null, // hook for future Croissant integration
+              }
+            : {}),
+          ...(responseRows ? { 'civic:responseRows': Number(responseRows) } : {}),
+        }),
+      );
+    }
+
+    // Tool call activity — associated with the MCP source agent that handled
+    // the call. In multi-source analyses each call may target a different
+    // agent (e.g. socrata for `get_data`, data-commons for `get_observations`).
+    const durationMs = getAttr(span.attributes, 'tool.duration_ms');
+    graph.push(
+      makeActivityNode(toolCallUrn, {
+        'dcterms:description': `MCP tool call: ${toolName} (${opType})`,
+        'civic:sourceId': toolSource,
+        ...provUsed([queryUrn]),
+        ...provWasAssociatedWith(toolAgentUrn),
+        ...(span.startTimeUnixNano
+          ? { 'prov:startedAtTime': xsdDateTime(nanoToIso(span.startTimeUnixNano)) }
+          : {}),
+        ...(span.endTimeUnixNano
+          ? { 'prov:endedAtTime': xsdDateTime(nanoToIso(span.endTimeUnixNano)) }
+          : {}),
+        ...(durationMs ? { 'civic:durationMs': Number(durationMs) } : {}),
+      }),
+    );
+  }
+
+  // --- Final output relationships ---
+
+  // Output wasGeneratedBy the last inference or synthesis span
+  const synthesisSpan = spans.find(s => s.name === 'synthesis');
+  const lastInference = inferenceSpans.length > 0
+    ? inferenceSpans[inferenceSpans.length - 1]
+    : undefined;
+  const generatorSpan = synthesisSpan || lastInference;
+
+  if (generatorSpan) {
+    const generatorUrn = synthesisSpan
+      ? civicUrn(packageId, 'synthesis', synthesisSpan.spanId)
+      : civicUrn(packageId, 'inference', generatorSpan.spanId);
+
+    // Add synthesis activity if it exists
+    if (synthesisSpan) {
+      graph.push(
+        makeActivityNode(generatorUrn, {
+          'dcterms:description': 'Output synthesis',
+          ...provWasAssociatedWith(modelUrn),
+          ...(synthesisSpan.startTimeUnixNano
+            ? { 'prov:startedAtTime': xsdDateTime(nanoToIso(synthesisSpan.startTimeUnixNano)) }
+            : {}),
+          ...(synthesisSpan.endTimeUnixNano
+            ? { 'prov:endedAtTime': xsdDateTime(nanoToIso(synthesisSpan.endTimeUnixNano)) }
+            : {}),
+        }),
+      );
+    }
+
+    // Output wasGeneratedBy
+    graph.push(
+      makeEntityNode(civicUrn(packageId, 'output', outputHash), {
+        ...provWasGeneratedBy(generatorUrn),
+        ...(dataResponseUrns.length > 0
+          ? provWasDerivedFrom(dataResponseUrns)
+          : {}),
+      }),
+    );
+  }
+
+  // Add data responses to inference used list (inference used data to synthesize)
+  if (dataResponseUrns.length > 0 && inferenceUrns.length > 0) {
+    const lastInferenceUrn = inferenceUrns[inferenceUrns.length - 1];
+    const existing = graph.find(n => n['@id'] === lastInferenceUrn);
+    if (existing && Array.isArray(existing['prov:used'])) {
+      for (const dUrn of dataResponseUrns) {
+        (existing['prov:used'] as ProvNodeRef[]).push(provRef(dUrn));
+      }
+    }
+  }
+
+  // --- Skill hadPlan relationship ---
+  if (skillHash && inferenceUrns.length > 0) {
+    graph.push(
+      makeActivityNode(inferenceUrns[0], {
+        'prov:qualifiedAssociation': {
+          '@type': 'prov:Association',
+          'prov:agent': provRef(modelUrn),
+          'prov:hadPlan': provRef(civicUrn(packageId, 'skill', skillHash)),
+        },
+      }),
+    );
+  }
+
+  return makeProvGraph(makeCivicProvContext(), graph);
+}

--- a/packages/civic-typed-harness/src/capture/skill-metadata.test.ts
+++ b/packages/civic-typed-harness/src/capture/skill-metadata.test.ts
@@ -1,0 +1,82 @@
+// Skill-metadata extraction tests: `skill_fetch` span walking and the
+// trace-as-BlobRef inspection fallback ported from the reference packager.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { extractSkillMetadata, traceForInspection } from './skill-metadata.ts';
+
+function skillTrace(attrs: Record<string, string>): Record<string, unknown> {
+  return {
+    resourceSpans: [
+      {
+        scopeSpans: [
+          {
+            spans: [
+              {
+                name: 'skill_fetch',
+                attributes: Object.entries(attrs).map(([key, stringValue]) => ({
+                  key,
+                  value: { stringValue },
+                })),
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+}
+
+test('extracts hash, server URL, and skill text from the skill_fetch span', () => {
+  const meta = extractSkillMetadata(
+    skillTrace({
+      'skill.text_hash': 'abc123',
+      'skill.mcp_server_url': 'https://socrata-mcp.civicaitools.org',
+      'skill.text': 'You are a civic data analyst…',
+    }),
+  );
+  assert.deepEqual(meta, {
+    systemPromptHash: 'abc123',
+    mcpServerUrl: 'https://socrata-mcp.civicaitools.org',
+    skillText: 'You are a civic data analyst…',
+  });
+});
+
+test('missing attributes come back undefined (empty strings coerce to undefined)', () => {
+  const meta = extractSkillMetadata(skillTrace({ 'skill.text_hash': 'abc123' }));
+  assert.equal(meta.systemPromptHash, 'abc123');
+  assert.equal(meta.mcpServerUrl, undefined);
+  assert.equal(meta.skillText, undefined);
+});
+
+test('no skill_fetch span → empty result', () => {
+  assert.deepEqual(
+    extractSkillMetadata({
+      resourceSpans: [{ scopeSpans: [{ spans: [{ name: 'llm_inference', attributes: [] }] }] }],
+    }),
+    {},
+  );
+});
+
+test('non-span-shaped trace → empty result, no throw', () => {
+  assert.deepEqual(extractSkillMetadata({}), {});
+  assert.deepEqual(extractSkillMetadata({ resourceSpans: 'garbage' as unknown as [] }), {});
+});
+
+test('traceForInspection passes span-shaped traces through unchanged', () => {
+  const trace = skillTrace({ 'skill.text_hash': 'abc' });
+  assert.equal(traceForInspection(trace), trace);
+});
+
+test('traceForInspection degrades a BlobRef trace to the empty trace', () => {
+  const blobRef = {
+    ref: 'blob:sha256:1111111111111111111111111111111111111111111111111111111111111111',
+    url: 'https://blob.example/traces/1111.json',
+    contentType: 'application/json',
+    size: 1024,
+  };
+  const inspectable = traceForInspection(blobRef);
+  assert.deepEqual(inspectable, { resourceSpans: [] });
+  // Downstream extraction degrades gracefully on the empty trace.
+  assert.deepEqual(extractSkillMetadata(inspectable), {});
+});

--- a/packages/civic-typed-harness/src/capture/skill-metadata.ts
+++ b/packages/civic-typed-harness/src/capture/skill-metadata.ts
@@ -1,0 +1,59 @@
+// Skill-metadata extraction (CAPTURE group) — OTel `skill_fetch` span
+// walking, relocated from civic-ai-tools-website
+// `src/lib/evidence/packager.ts:303–322` (extraction) and `:354–357` (the
+// trace-as-BlobRef inspection fallback) per the S2 brief §1.
+
+import { isBlobRef } from '@typedstandards/verify-core';
+import type { BlobRef } from '@typedstandards/produce-core';
+
+/** Skill metadata extracted from a trace's `skill_fetch` span. Feeds the
+ *  envelope's `skillMetadata` block (and the datHere policy's
+ *  `skillMcpServerUrl` input). */
+export interface ExtractedSkillMetadata {
+  systemPromptHash?: string;
+  mcpServerUrl?: string;
+  skillText?: string;
+}
+
+/**
+ * Extract skill metadata from the trace's `skill_fetch` span. Returns `{}`
+ * when the trace has no such span (or is not span-shaped) — callers shipping
+ * trace-as-BlobRef should supply an explicit override instead (the packager
+ * cannot inspect spans it does not have).
+ */
+export function extractSkillMetadata(
+  trace: Record<string, unknown>,
+): ExtractedSkillMetadata {
+  try {
+    // Untyped walk over the caller's trace shape.
+    const spans = (trace as any)?.resourceSpans?.[0]?.scopeSpans?.[0]?.spans;
+    if (!Array.isArray(spans)) return {};
+    const skillSpan = spans.find((s: { name: string }) => s.name === 'skill_fetch');
+    if (!skillSpan) return {};
+    const attrs: Record<string, string> = {};
+    for (const a of skillSpan.attributes || []) {
+      attrs[a.key] = a.value?.stringValue || '';
+    }
+    return {
+      systemPromptHash: attrs['skill.text_hash'] || undefined,
+      mcpServerUrl: attrs['skill.mcp_server_url'] || undefined,
+      skillText: attrs['skill.text'] || undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Resolve the span-walkable view of a trace input. When the trace is a
+ * BlobRef the capture machinery cannot inspect spans (data-source detection,
+ * skill extraction, PROV-O construction all degrade gracefully on the empty
+ * trace this returns); otherwise the trace object passes through unchanged.
+ */
+export function traceForInspection(
+  trace: Record<string, unknown> | BlobRef,
+): Record<string, unknown> {
+  return isBlobRef(trace)
+    ? { resourceSpans: [] }
+    : (trace as Record<string, unknown>);
+}

--- a/packages/civic-typed-harness/src/capture/trace.test.ts
+++ b/packages/civic-typed-harness/src/capture/trace.test.ts
@@ -1,0 +1,172 @@
+// TraceBuilder tests: injectable clock/RNG (determinism), config-not-constants
+// for the resource/scope identity, the noble-backed hash(), and the OTel
+// trace shape the reference implementation emitted.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import {
+  TraceBuilder,
+  hash,
+  CIVICAITOOLS_TRACE_CONFIG,
+  type TraceBuilderConfig,
+} from './trace.ts';
+
+// Fixture convention: synthetic timestamps stay under 13 digits and seeded
+// ids start in the hex-letter range (0xa0…) so no fixture value can
+// pattern-match as a payment-card-shaped digit run in pre-push sensitivity scans.
+
+/** Deterministic RNG: counts up from 0xa0 so ids are distinct, stable, and
+ *  always contain hex letters. */
+function seededBytes(): (n: number) => Uint8Array {
+  let counter = 0xa0;
+  return (n: number) => {
+    const buf = new Uint8Array(n);
+    for (let i = 0; i < n; i++) buf[i] = (counter + i) % 256;
+    counter += n;
+    return buf;
+  };
+}
+
+function deterministicConfig(overrides: Partial<TraceBuilderConfig> = {}): TraceBuilderConfig {
+  let t = 100000; // ms clock seed — nano strings stay 12 digits
+  return {
+    ...CIVICAITOOLS_TRACE_CONFIG,
+    now: () => t++,
+    randomBytes: seededBytes(),
+    ...overrides,
+  };
+}
+
+test('hash() matches node:crypto SHA-256 hex (noble backend is byte-identical)', () => {
+  for (const input of ['', 'hello world', 'civic-typed-harness é中文']) {
+    const expected = crypto.createHash('sha256').update(input).digest('hex');
+    assert.equal(hash(input), expected);
+  }
+});
+
+test('injected clock + RNG make the whole trace deterministic', () => {
+  const build = () => {
+    const tb = new TraceBuilder(deterministicConfig());
+    tb.startRoot('analysis', { 'analysis.prompt_hash': 'abc' });
+    const s1 = tb.startSpan('llm_inference', undefined, { 'gen_ai.inference_index': 0 });
+    tb.recordEvent(s1, 'first_token');
+    tb.endSpan(s1, { 'gen_ai.response.completion_tokens': 42 });
+    const s2 = tb.startSpan('mcp_tool_call');
+    tb.endSpan(s2);
+    tb.endRoot();
+    return tb.finalize();
+  };
+  const a = build();
+  const b = build();
+  assert.equal(JSON.stringify(a), JSON.stringify(b));
+});
+
+test('trace/span ids come from the injected RNG (128-bit trace, 64-bit spans)', () => {
+  const tb = new TraceBuilder(deterministicConfig());
+  assert.equal(tb.traceId, 'a0a1a2a3a4a5a6a7a8a9aaabacadaeaf');
+  assert.equal(tb.rootSpanId, 'b0b1b2b3b4b5b6b7');
+  assert.equal(tb.traceId.length, 32);
+  assert.equal(tb.rootSpanId.length, 16);
+});
+
+test('timestamps come from the injected clock, as ms-precision nano strings', () => {
+  const config = deterministicConfig();
+  const tb = new TraceBuilder(config);
+  tb.startRoot('analysis');
+  const spanId = tb.startSpan('llm_inference');
+  tb.endSpan(spanId);
+  const otel = tb.finalize();
+  const spans = otel.resourceSpans[0].scopeSpans[0].spans;
+  const root = spans.find((s) => s.spanId === tb.rootSpanId)!;
+  assert.equal(root.startTimeUnixNano, '100000000000');
+  const child = spans.find((s) => s.spanId === spanId)!;
+  assert.equal(child.startTimeUnixNano, '100001000000');
+  assert.equal(child.endTimeUnixNano, '100002000000');
+});
+
+test('resource + scope identity comes from config (demo defaults preserved)', () => {
+  const tb = new TraceBuilder(deterministicConfig());
+  const otel = tb.finalize();
+  const resourceAttrs = Object.fromEntries(
+    otel.resourceSpans[0].resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(resourceAttrs['service.name'], 'civic-ai-tools-website');
+  assert.equal(resourceAttrs['service.version'], '0.1.0');
+  assert.equal(resourceAttrs['telemetry.sdk.language'], 'typescript');
+  assert.equal(resourceAttrs['otel.semconv.version'], '1.30.0');
+  assert.deepEqual(otel.resourceSpans[0].scopeSpans[0].scope, {
+    name: 'civic-ai-tools-evidence',
+    version: '0.1.0',
+  });
+});
+
+test('config injection: service.name and scope identity are per-instance inputs', () => {
+  const tb = new TraceBuilder(
+    deterministicConfig({
+      serviceName: 'city-evidence-portal',
+      scopeName: 'city-evidence-capture',
+      scopeVersion: '2.0.0',
+      semconvVersion: '1.31.0',
+    }),
+  );
+  const otel = tb.finalize();
+  const resourceAttrs = Object.fromEntries(
+    otel.resourceSpans[0].resource.attributes.map((a) => [a.key, a.value.stringValue]),
+  );
+  assert.equal(resourceAttrs['service.name'], 'city-evidence-portal');
+  assert.equal(resourceAttrs['service.version'], '2.0.0');
+  assert.equal(resourceAttrs['otel.semconv.version'], '1.31.0');
+  assert.deepEqual(otel.resourceSpans[0].scopeSpans[0].scope, {
+    name: 'city-evidence-capture',
+    version: '2.0.0',
+  });
+});
+
+test('span parenting: default parent is the root span; kind codes match OTel', () => {
+  const tb = new TraceBuilder(deterministicConfig());
+  tb.startRoot('analysis');
+  const s1 = tb.startSpan('llm_inference');
+  const s2 = tb.startSpan('mcp_tool_call', s1);
+  const otel = tb.finalize();
+  const spans = otel.resourceSpans[0].scopeSpans[0].spans;
+  const root = spans.find((s) => s.spanId === tb.rootSpanId)!;
+  assert.equal(root.parentSpanId, undefined);
+  assert.equal(root.kind, 2); // SERVER
+  const first = spans.find((s) => s.spanId === s1)!;
+  assert.equal(first.parentSpanId, tb.rootSpanId);
+  assert.equal(first.kind, 1); // INTERNAL
+  const second = spans.find((s) => s.spanId === s2)!;
+  assert.equal(second.parentSpanId, s1);
+});
+
+test('finalize() closes any span that was never ended', () => {
+  const tb = new TraceBuilder(deterministicConfig());
+  tb.startRoot('analysis');
+  tb.startSpan('llm_inference'); // never ended
+  const otel = tb.finalize();
+  for (const span of otel.resourceSpans[0].scopeSpans[0].spans) {
+    assert.ok(span.endTimeUnixNano, `span ${span.name} should be closed at finalize`);
+  }
+});
+
+test('attribute typing: numbers → intValue strings, booleans → boolValue', () => {
+  const tb = new TraceBuilder(deterministicConfig());
+  const s = tb.startSpan('llm_inference', undefined, {
+    'tokens': 42,
+    'cached': true,
+    'model': 'openai/gpt-4o',
+  });
+  const otel = tb.finalize();
+  const span = otel.resourceSpans[0].scopeSpans[0].spans.find((x) => x.spanId === s)!;
+  const byKey = Object.fromEntries(span.attributes.map((a) => [a.key, a.value]));
+  assert.deepEqual(byKey['tokens'], { intValue: '42' });
+  assert.deepEqual(byKey['cached'], { boolValue: true });
+  assert.deepEqual(byKey['model'], { stringValue: 'openai/gpt-4o' });
+});
+
+test('default construction (no injected clock/RNG) still produces well-formed ids', () => {
+  const tb = new TraceBuilder();
+  assert.match(tb.traceId, /^[0-9a-f]{32}$/);
+  assert.match(tb.rootSpanId, /^[0-9a-f]{16}$/);
+});

--- a/packages/civic-typed-harness/src/capture/trace.ts
+++ b/packages/civic-typed-harness/src/capture/trace.ts
@@ -1,0 +1,263 @@
+// OTel-compatible trace capture (CAPTURE group) — types + TraceBuilder,
+// relocated whole from civic-ai-tools-website `src/lib/evidence/trace.ts:1–199`
+// per the S2 brief §1, with two changes:
+//   - `hash()` is re-backed by the @noble/hashes SHA-256 exported through
+//     @typedstandards/verify-core (produce-core's own dependency), removing
+//     the module's only `node:crypto` use — the harness is browser-safe.
+//   - The resource/scope identity constants (`service.name`, scope
+//     name/version, semconv version) are typed config inputs with the demo
+//     values as the exported default (config-not-constants, S2 brief §2).
+//
+// Clock + RNG are INHERENT to capture (span timestamps and ids are what
+// capture *is*): this module is the sanctioned exception to the package's
+// determinism rule, and both are injectable for deterministic tests.
+
+import { sha256Hex } from '@typedstandards/verify-core';
+
+// --- Types (OTel-compatible trace format) ---
+
+export interface SpanEvent {
+  timeUnixNano: string;
+  name: string;
+  attributes: OTelAttribute[];
+}
+
+export interface OTelAttribute {
+  key: string;
+  value: { stringValue?: string; intValue?: string; boolValue?: boolean };
+}
+
+export interface Span {
+  traceId: string;
+  spanId: string;
+  parentSpanId?: string;
+  name: string;
+  kind: number; // 1=INTERNAL, 2=SERVER, 3=CLIENT
+  startTimeUnixNano: string;
+  endTimeUnixNano?: string;
+  attributes: OTelAttribute[];
+  events: SpanEvent[];
+  status: { code: number }; // 0=UNSET, 1=OK, 2=ERROR
+}
+
+export interface OTelTrace {
+  resourceSpans: Array<{
+    resource: {
+      attributes: OTelAttribute[];
+    };
+    scopeSpans: Array<{
+      scope: { name: string; version: string };
+      spans: Span[];
+    }>;
+  }>;
+}
+
+// --- Helpers ---
+
+function toAttr(key: string, value: string | number | boolean): OTelAttribute {
+  if (typeof value === 'number') {
+    return { key, value: { intValue: String(value) } };
+  }
+  if (typeof value === 'boolean') {
+    return { key, value: { boolValue: value } };
+  }
+  return { key, value: { stringValue: value } };
+}
+
+function attrsFromRecord(attrs?: Record<string, string | number | boolean>): OTelAttribute[] {
+  if (!attrs) return [];
+  return Object.entries(attrs).map(([k, v]) => toAttr(k, v));
+}
+
+/** SHA-256 hash of a string, returned as hex. Backed by @noble/hashes via
+ *  verify-core — same digest bytes as `node:crypto`, browser-safe. */
+export function hash(content: string): string {
+  return sha256Hex(content);
+}
+
+// --- TraceBuilder configuration ---
+
+/** Millisecond clock. Injectable for deterministic tests. */
+export type TraceClock = () => number;
+
+/** Cryptographically-random byte source. Injectable for deterministic
+ *  tests. */
+export type TraceRandomBytes = (byteLength: number) => Uint8Array;
+
+/**
+ * TraceBuilder identity + determinism inputs. The identity strings name the
+ * capturing service, so they are per-instance config (config-not-constants);
+ * the demo values are `CIVICAITOOLS_TRACE_CONFIG` below.
+ */
+export interface TraceBuilderConfig {
+  /** OTel resource `service.name`. */
+  serviceName: string;
+  /** Instrumentation scope name. */
+  scopeName: string;
+  /** Scope version — also emitted as resource `service.version`. */
+  scopeVersion: string;
+  /** OTel semantic-conventions version advertised on the resource. */
+  semconvVersion: string;
+  /** Millisecond clock; defaults to `Date.now`. */
+  now?: TraceClock;
+  /** Random byte source for trace/span ids; defaults to the runtime's
+   *  `crypto.getRandomValues` (Web Crypto — Node 18+ and every browser). */
+  randomBytes?: TraceRandomBytes;
+}
+
+/** Demo default: the civicaitools.org reference deployment's capture
+ *  identity. */
+export const CIVICAITOOLS_TRACE_CONFIG: TraceBuilderConfig = {
+  serviceName: 'civic-ai-tools-website',
+  scopeName: 'civic-ai-tools-evidence',
+  scopeVersion: '0.1.0',
+  semconvVersion: '1.30.0',
+};
+
+function defaultRandomBytes(byteLength: number): Uint8Array {
+  const buf = new Uint8Array(byteLength);
+  globalThis.crypto.getRandomValues(buf);
+  return buf;
+}
+
+// --- TraceBuilder ---
+
+export class TraceBuilder {
+  readonly traceId: string;
+  readonly rootSpanId: string;
+  private spans: Map<string, Span> = new Map();
+  private readonly config: TraceBuilderConfig;
+  private readonly now: TraceClock;
+  private readonly randomBytes: TraceRandomBytes;
+
+  constructor(config: TraceBuilderConfig = CIVICAITOOLS_TRACE_CONFIG) {
+    this.config = config;
+    this.now = config.now ?? Date.now;
+    this.randomBytes = config.randomBytes ?? defaultRandomBytes;
+    this.traceId = this.randomHex(16); // 128-bit
+    this.rootSpanId = this.randomHex(8); // 64-bit
+  }
+
+  private randomHex(bytes: number): string {
+    return Array.from(this.randomBytes(bytes), (b) =>
+      b.toString(16).padStart(2, '0'),
+    ).join('');
+  }
+
+  private nowNano(): string {
+    // millisecond precision expressed as nanoseconds string
+    return `${this.now()}000000`;
+  }
+
+  /**
+   * Start a new span. Returns the span ID.
+   * If no parentSpanId is given, the span is parented to the root.
+   */
+  startSpan(
+    name: string,
+    parentSpanId?: string,
+    attributes?: Record<string, string | number | boolean>,
+  ): string {
+    const spanId = this.randomHex(8);
+    this.spans.set(spanId, {
+      traceId: this.traceId,
+      spanId,
+      parentSpanId: parentSpanId ?? this.rootSpanId,
+      name,
+      kind: 1, // INTERNAL
+      startTimeUnixNano: this.nowNano(),
+      attributes: attrsFromRecord(attributes),
+      events: [],
+      status: { code: 0 },
+    });
+    return spanId;
+  }
+
+  /** End a span, optionally merging additional attributes. */
+  endSpan(spanId: string, attributes?: Record<string, string | number | boolean>): void {
+    const span = this.spans.get(spanId);
+    if (!span) return;
+    span.endTimeUnixNano = this.nowNano();
+    if (attributes) {
+      span.attributes.push(...attrsFromRecord(attributes));
+    }
+  }
+
+  /** Record a point-in-time event within an existing span. */
+  recordEvent(
+    spanId: string,
+    name: string,
+    attributes?: Record<string, string | number | boolean>,
+  ): void {
+    const span = this.spans.get(spanId);
+    if (!span) return;
+    span.events.push({
+      timeUnixNano: this.nowNano(),
+      name,
+      attributes: attrsFromRecord(attributes),
+    });
+  }
+
+  /**
+   * Start the root span. Call this at the very beginning of the analysis.
+   * The root span uses the pre-generated rootSpanId.
+   */
+  startRoot(
+    name: string,
+    attributes?: Record<string, string | number | boolean>,
+  ): void {
+    this.spans.set(this.rootSpanId, {
+      traceId: this.traceId,
+      spanId: this.rootSpanId,
+      // root has no parent
+      name,
+      kind: 2, // SERVER
+      startTimeUnixNano: this.nowNano(),
+      attributes: attrsFromRecord(attributes),
+      events: [],
+      status: { code: 0 },
+    });
+  }
+
+  /** End the root span. */
+  endRoot(attributes?: Record<string, string | number | boolean>): void {
+    this.endSpan(this.rootSpanId, attributes);
+  }
+
+  /**
+   * Finalize and return the complete trace as OTel-compatible JSON.
+   * Any spans that were started but not ended are closed at finalize time.
+   */
+  finalize(): OTelTrace {
+    const finalTime = this.nowNano();
+    for (const span of this.spans.values()) {
+      if (!span.endTimeUnixNano) {
+        span.endTimeUnixNano = finalTime;
+      }
+    }
+
+    return {
+      resourceSpans: [
+        {
+          resource: {
+            attributes: [
+              toAttr('service.name', this.config.serviceName),
+              toAttr('service.version', this.config.scopeVersion),
+              toAttr('telemetry.sdk.language', 'typescript'),
+              toAttr('otel.semconv.version', this.config.semconvVersion),
+            ],
+          },
+          scopeSpans: [
+            {
+              scope: {
+                name: this.config.scopeName,
+                version: this.config.scopeVersion,
+              },
+              spans: Array.from(this.spans.values()),
+            },
+          ],
+        },
+      ],
+    };
+  }
+}

--- a/packages/civic-typed-harness/src/format/dathere.test.ts
+++ b/packages/civic-typed-harness/src/format/dathere.test.ts
@@ -1,0 +1,198 @@
+// datHere-policy tests: the derivations ported from the reference packager
+// (producerProfile, canonicalization selection, summary emission, environment
+// extension), the host config input, and the derive→assemble seam — the
+// derived fields feed produce-core's buildEnvelope and reproduce the
+// packager's conditional-emission behavior (ported from the reference
+// packager.test.ts ADR-0004 section).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  DATHERE_PRODUCER_PROFILE,
+  DATHERE_CONTENT_PROFILE,
+  ENVIRONMENT_EXTENSION_KEY,
+  CIVICAITOOLS_ENVIRONMENT_HOST,
+  deriveProducerProfile,
+  selectContentCanonicalization,
+  deriveSummaryEmission,
+  buildDatHereEnvironment,
+  deriveDatHereEnvelopeFields,
+} from './dathere.ts';
+import { buildEnvelope, type EnvelopeInput } from '@typedstandards/produce-core';
+import {
+  LEGACY_JSON_CANONICALIZATION,
+  DATHERE_AG_JUPYTER_CANONICALIZATION,
+} from '@typedstandards/verify-core';
+
+test('producerProfile: auto-derived for datHere, absent otherwise, explicit wins', () => {
+  assert.equal(deriveProducerProfile(undefined, 'datHere'), 'ai-assisted-analysis/datHere');
+  assert.equal(deriveProducerProfile(undefined, undefined), undefined);
+  assert.equal(deriveProducerProfile(undefined, 'default'), undefined);
+  assert.equal(
+    deriveProducerProfile('ai-assisted-analysis/other', 'datHere'),
+    'ai-assisted-analysis/other',
+  );
+  assert.equal(DATHERE_PRODUCER_PROFILE, 'ai-assisted-analysis/datHere');
+});
+
+test('canonicalization selection: dathere-ag-jupyter/v1 for datHere, legacy-json/v1 otherwise', () => {
+  assert.equal(
+    selectContentCanonicalization('datHere'),
+    DATHERE_AG_JUPYTER_CANONICALIZATION,
+  );
+  assert.equal(selectContentCanonicalization(undefined), LEGACY_JSON_CANONICALIZATION);
+  assert.equal(selectContentCanonicalization('default'), LEGACY_JSON_CANONICALIZATION);
+  // The rule URIs are verify-core's — re-emitted, never redefined.
+  assert.ok(DATHERE_AG_JUPYTER_CANONICALIZATION.endsWith('/dathere-ag-jupyter/v1'));
+  assert.ok(LEGACY_JSON_CANONICALIZATION.endsWith('/legacy-json/v1'));
+});
+
+test('summary emission: only under the datHere profile, and only when non-empty', () => {
+  assert.equal(deriveSummaryEmission('datHere', 'A summary.'), 'A summary.');
+  assert.equal(deriveSummaryEmission(undefined, 'A summary.'), undefined);
+  assert.equal(deriveSummaryEmission('default', 'A summary.'), undefined);
+  assert.equal(deriveSummaryEmission('datHere', undefined), undefined);
+  assert.equal(deriveSummaryEmission('datHere', ''), undefined);
+});
+
+test('environment extension: OES §9.1.1 field set, host from config (demo default)', () => {
+  const env = buildDatHereEnvironment('openai/gpt-4o', 'https://socrata-mcp.civicaitools.org');
+  assert.deepEqual(env, {
+    modelVersion: 'openai/gpt-4o',
+    temperature: 0,
+    mcpServers: [{ url: 'https://socrata-mcp.civicaitools.org' }],
+    toolDefinitions: [],
+    host: CIVICAITOOLS_ENVIRONMENT_HOST,
+  });
+  // Key order is part of the byte contract on the legacy chain.
+  assert.deepEqual(Object.keys(env), [
+    'modelVersion',
+    'temperature',
+    'mcpServers',
+    'toolDefinitions',
+    'host',
+  ]);
+});
+
+test('environment extension: host is a config input, not a constant', () => {
+  const env = buildDatHereEnvironment('openai/gpt-4o', undefined, {
+    host: 'evidence.city.example',
+  });
+  assert.equal(env.host, 'evidence.city.example');
+  assert.deepEqual(env.mcpServers, []);
+});
+
+test('composite derivation: datHere input produces all four envelope fields', () => {
+  const fields = deriveDatHereEnvelopeFields({
+    model: 'openai/gpt-4o',
+    contentProfile: DATHERE_CONTENT_PROFILE,
+    summary: 'Short summary.',
+    skillMcpServerUrl: 'https://socrata-mcp.civicaitools.org',
+    extensions: { 'org.civicaitools.notebook': { cells: [] } },
+  });
+  assert.equal(fields.producerProfile, DATHERE_PRODUCER_PROFILE);
+  assert.equal(fields.contentCanonicalization, DATHERE_AG_JUPYTER_CANONICALIZATION);
+  assert.equal(fields.summary, 'Short summary.');
+  assert.ok(fields.extensions);
+  // Caller extensions are preserved; the environment extension layers on top.
+  assert.ok(fields.extensions!['org.civicaitools.notebook']);
+  const env = fields.extensions![ENVIRONMENT_EXTENSION_KEY] as Record<string, unknown>;
+  assert.equal(env.modelVersion, 'openai/gpt-4o');
+  assert.equal(env.host, CIVICAITOOLS_ENVIRONMENT_HOST);
+});
+
+test('composite derivation: non-datHere input emits neither summary nor environment extension', () => {
+  const fields = deriveDatHereEnvelopeFields({
+    model: 'openai/gpt-4o',
+    summary: 'Provided but not emitted.',
+  });
+  assert.equal(fields.producerProfile, undefined);
+  assert.equal(fields.contentCanonicalization, LEGACY_JSON_CANONICALIZATION);
+  assert.equal(fields.summary, undefined);
+  assert.equal(fields.extensions, undefined);
+});
+
+// --- The derive→assemble seam (ADR-0021: the harness derives, the core
+// --- assembles). Ported behaviors from the reference packager.test.ts.
+
+function envelopeInput(overrides: Partial<EnvelopeInput> = {}): EnvelopeInput {
+  return {
+    packageId: '00000000-0000-4000-8000-000000000001',
+    createdAt: '2026-08-01T00:00:00.000Z',
+    signingKeyId: 'platform:test-key',
+    prompt: 'How many noise complaints?',
+    promptVisibility: 'full_text',
+    queries: [],
+    dataSources: [],
+    cost: { model: 'openai/gpt-4o' },
+    skillMetadata: {},
+    output: 'There were 12 complaints.',
+    trace: { resourceSpans: [] },
+    ...overrides,
+  };
+}
+
+function datHereAssembled(model = 'openai/gpt-4o', summary = 'Test summary.') {
+  const fields = deriveDatHereEnvelopeFields({
+    model,
+    contentProfile: DATHERE_CONTENT_PROFILE,
+    summary,
+    skillMcpServerUrl: 'https://socrata-mcp.civicaitools.org',
+    // v0.1 datHere packages carry the executed notebook (the
+    // dathere-ag-jupyter/v1 content hash fingerprints it) — the publish flow
+    // supplies it as a caller extension; a stub stands in here.
+    extensions: {
+      'org.civicaitools.notebook': { nbformat: 4, nbformat_minor: 5, cells: [] },
+    },
+  });
+  return buildEnvelope(
+    envelopeInput({
+      cost: { model },
+      captureMethod: 'chat-flow-stream',
+      contentProfile: DATHERE_CONTENT_PROFILE,
+      type: 'content/analysis/v1',
+      ...fields,
+    }),
+  );
+}
+
+test('assembled datHere envelope carries summary in canonical JSON', () => {
+  const { pkg } = datHereAssembled();
+  assert.equal(pkg.summary, 'Test summary.');
+  assert.ok(Object.prototype.hasOwnProperty.call(pkg, 'summary'));
+});
+
+test('assembled datHere envelope auto-carries the environment extension', () => {
+  const { pkg } = datHereAssembled();
+  const env = pkg.extensions?.[ENVIRONMENT_EXTENSION_KEY] as Record<string, unknown>;
+  assert.ok(env, 'environment extension should be present');
+  assert.equal(env.modelVersion, 'openai/gpt-4o');
+  assert.equal(env.host, CIVICAITOOLS_ENVIRONMENT_HOST);
+  assert.equal(pkg.producerProfile, DATHERE_PRODUCER_PROFILE);
+  assert.equal(pkg.contentCanonicalization, DATHERE_AG_JUPYTER_CANONICALIZATION);
+});
+
+test('assembled non-datHere envelope emits neither summary nor environment extension', () => {
+  const fields = deriveDatHereEnvelopeFields({
+    model: 'openai/gpt-4o',
+    summary: 'Provided but off-envelope.',
+  });
+  const { pkg } = buildEnvelope(
+    envelopeInput({ captureMethod: 'chat-flow-stream', ...fields }),
+  );
+  assert.equal(JSON.stringify(pkg).includes('"summary"'), false);
+  assert.equal(pkg.extensions?.[ENVIRONMENT_EXTENSION_KEY], undefined);
+  assert.equal(pkg.producerProfile, undefined);
+});
+
+test('summary value is part of the envelope hash for datHere (tamper-evidence)', () => {
+  const a = datHereAssembled('openai/gpt-4o', 'Summary A');
+  const b = datHereAssembled('openai/gpt-4o', 'Summary B');
+  assert.notEqual(a.envelopeHash, b.envelopeHash);
+});
+
+test('environment modelVersion is part of the envelope hash for datHere (tamper-evidence)', () => {
+  const a = datHereAssembled('openai/gpt-4o');
+  const b = datHereAssembled('anthropic/claude-3-5-sonnet');
+  assert.notEqual(a.envelopeHash, b.envelopeHash);
+});

--- a/packages/civic-typed-harness/src/format/dathere.ts
+++ b/packages/civic-typed-harness/src/format/dathere.ts
@@ -1,0 +1,180 @@
+// datHere envelope policy (FORMAT-EXTENSION group) — the derivations the
+// reference app's packager did inline, relocated from civic-ai-tools-website
+// `src/lib/evidence/packager.ts` per the S2 brief §1:
+//   - `:26`       DATHERE_PRODUCER_PROFILE constant
+//   - `:286–301`  `org.civicaitools.environment` extension builder
+//   - `:393–395`  producerProfile derivation
+//   - `:407–410`  content-canonicalization rule selection
+//   - `:464–466`  summary-emission decision
+//   - `:477–484`  extension layering
+//
+// Output = explicit envelope-field values for @typedstandards/produce-core's
+// `buildEnvelope` (ADR-0021's operating rule: the harness DERIVES, the core
+// ASSEMBLES). Byte discipline: every field is emitted exactly when the
+// reference packager emitted it, so equivalent inputs produce byte-identical
+// canonical JSON through the core's conditional spreads.
+//
+// The canonicalization rule URIs come from @typedstandards/verify-core
+// (produce-core's own dependency — present transitively by construction);
+// the harness re-emits, never redefines, them.
+
+import {
+  DATHERE_AG_JUPYTER_CANONICALIZATION,
+  LEGACY_JSON_CANONICALIZATION,
+} from '@typedstandards/verify-core';
+
+/** The datHere content-profile label (ADR-0004). */
+export const DATHERE_CONTENT_PROFILE = 'datHere';
+
+/** Producer Profile auto-derived for the datHere content profile (ADR-0006):
+ *  compound `<profile-type>/<profile-subtype>`. */
+export const DATHERE_PRODUCER_PROFILE = 'ai-assisted-analysis/datHere';
+
+/** Reverse-DNS key of the auto-emitted environment extension. */
+export const ENVIRONMENT_EXTENSION_KEY = 'org.civicaitools.environment';
+
+/** Demo default for the environment extension's `host` field: the
+ *  civicaitools.org reference deployment. Config-not-constants — every other
+ *  instance supplies its own via `DatHereEnvironmentConfig`. */
+export const CIVICAITOOLS_ENVIRONMENT_HOST = 'civicaitools.org';
+
+/** Per-instance configuration for the environment extension. */
+export interface DatHereEnvironmentConfig {
+  /** Publishing host recorded in `org.civicaitools.environment.host`. */
+  host: string;
+}
+
+/** The civicaitools.org demo default. */
+export const CIVICAITOOLS_ENVIRONMENT_CONFIG: DatHereEnvironmentConfig = {
+  host: CIVICAITOOLS_ENVIRONMENT_HOST,
+};
+
+/**
+ * Derive the envelope's `producerProfile` (ADR-0006): the explicit value when
+ * supplied, else auto-derived from the datHere content profile, else
+ * `undefined` (and thereby unemitted — pre-ADR-0006 canonical JSON stays
+ * byte-identical).
+ */
+export function deriveProducerProfile(
+  producerProfile?: string,
+  contentProfile?: string,
+): string | undefined {
+  return (
+    producerProfile
+    ?? (contentProfile === DATHERE_CONTENT_PROFILE
+      ? DATHERE_PRODUCER_PROFILE
+      : undefined)
+  );
+}
+
+/**
+ * Select the content-canonicalization rule URI (spec §8.2) for a content
+ * profile: `dathere-ag-jupyter/v1` for datHere (fingerprints the executed
+ * notebook), `legacy-json/v1` for everything else (whole-package rule).
+ */
+export function selectContentCanonicalization(contentProfile?: string): string {
+  return contentProfile === DATHERE_CONTENT_PROFILE
+    ? DATHERE_AG_JUPYTER_CANONICALIZATION
+    : LEGACY_JSON_CANONICALIZATION;
+}
+
+/**
+ * Summary-emission decision (ADR-0004 §7): the datHere profile REQUIRES the
+ * summary in canonical JSON (covered by the envelope hash); every other
+ * profile keeps it off-envelope (DB-row only in the reference app), so their
+ * package hashes stay byte-identical to pre-ADR-0004 behavior. Returns the
+ * value to pass as the envelope's `summary` field, or `undefined` to omit.
+ */
+export function deriveSummaryEmission(
+  contentProfile?: string,
+  summary?: string,
+): string | undefined {
+  return contentProfile === DATHERE_CONTENT_PROFILE && summary
+    ? summary
+    : undefined;
+}
+
+/**
+ * Build the `org.civicaitools.environment` extension content for a datHere
+ * package. Per OES §9.1.1 requirement 3 the extension MUST carry
+ * `modelVersion`, `temperature`, `mcpServers`, `toolDefinitions`, `host`.
+ *
+ * Prototype limitations carried over from the reference implementation
+ * (known gaps, tightened in follow-up work): `temperature` placeholder `0`,
+ * `toolDefinitions` placeholder `[]`; `mcpServers` derives from the trace's
+ * skill-fetch span URL (the analysis's primary MCP server). Fields captured
+ * honestly: `modelVersion` and `host`.
+ */
+export function buildDatHereEnvironment(
+  model: string,
+  skillMcpServerUrl: string | undefined,
+  config: DatHereEnvironmentConfig = CIVICAITOOLS_ENVIRONMENT_CONFIG,
+): Record<string, unknown> {
+  const mcpServers: Array<{ url: string; name?: string }> = [];
+  if (skillMcpServerUrl) {
+    mcpServers.push({ url: skillMcpServerUrl });
+  }
+  return {
+    modelVersion: model,
+    temperature: 0,
+    mcpServers,
+    toolDefinitions: [],
+    host: config.host,
+  };
+}
+
+/** Input to the composite datHere-policy derivation. */
+export interface DatHerePolicyInput {
+  /** Model identifier (becomes `environment.modelVersion`). */
+  model: string;
+  /** Content-profile label; absence means the default profile. */
+  contentProfile?: string;
+  /** Explicit producerProfile — wins over auto-derivation when supplied. */
+  producerProfile?: string;
+  /** Candidate summary text (emitted only under the datHere profile). */
+  summary?: string;
+  /** MCP server URL from the trace's skill-fetch span (capture-side
+   *  extraction — see src/capture/skill-metadata.ts). */
+  skillMcpServerUrl?: string;
+  /** Caller-supplied extensions to layer the environment extension onto. */
+  extensions?: Record<string, unknown>;
+}
+
+/** The derived envelope-field values, ready to spread into produce-core's
+ *  `EnvelopeInput`. Fields are `undefined` exactly when the reference
+ *  packager left them unemitted. */
+export interface DatHereEnvelopeFields {
+  producerProfile?: string;
+  contentCanonicalization: string;
+  summary?: string;
+  extensions?: Record<string, unknown>;
+}
+
+/**
+ * Composite derivation: everything the reference packager derived inline for
+ * the datHere policy, as one call. Non-datHere inputs pass through with only
+ * the legacy canonicalization rule and any caller-supplied extensions —
+ * byte-identical envelopes via the core's conditional spreads.
+ */
+export function deriveDatHereEnvelopeFields(
+  input: DatHerePolicyInput,
+  config: DatHereEnvironmentConfig = CIVICAITOOLS_ENVIRONMENT_CONFIG,
+): DatHereEnvelopeFields {
+  const extensions: Record<string, unknown> = { ...(input.extensions ?? {}) };
+  if (input.contentProfile === DATHERE_CONTENT_PROFILE) {
+    extensions[ENVIRONMENT_EXTENSION_KEY] = buildDatHereEnvironment(
+      input.model,
+      input.skillMcpServerUrl,
+      config,
+    );
+  }
+  return {
+    producerProfile: deriveProducerProfile(
+      input.producerProfile,
+      input.contentProfile,
+    ),
+    contentCanonicalization: selectContentCanonicalization(input.contentProfile),
+    summary: deriveSummaryEmission(input.contentProfile, input.summary),
+    ...(Object.keys(extensions).length > 0 ? { extensions } : {}),
+  };
+}

--- a/packages/civic-typed-harness/src/format/profiles.test.ts
+++ b/packages/civic-typed-harness/src/format/profiles.test.ts
@@ -1,0 +1,33 @@
+// captureMethod vocabulary-surface tests: the harness's profile constants
+// must be consistent with verify-core's Q32 fallback table — by construction
+// (they ARE the table entry) and by assertion (this test locks the values).
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PROFILE_CAPTURE_VOCAB } from '@typedstandards/verify-core';
+import {
+  AI_ASSISTED_ANALYSIS_PROFILE_TYPE,
+  AI_ASSISTED_ANALYSIS_CAPTURE_METHODS,
+} from './profiles.ts';
+import { DATHERE_PRODUCER_PROFILE } from './dathere.ts';
+
+test('profile type matches the compound producerProfile prefix', () => {
+  assert.equal(AI_ASSISTED_ANALYSIS_PROFILE_TYPE, 'ai-assisted-analysis');
+  assert.equal(
+    DATHERE_PRODUCER_PROFILE.split('/')[0],
+    AI_ASSISTED_ANALYSIS_PROFILE_TYPE,
+  );
+});
+
+test('captureMethod vocabulary is verify-core\'s Q32 fallback-table entry (single-sourced)', () => {
+  assert.equal(
+    AI_ASSISTED_ANALYSIS_CAPTURE_METHODS,
+    PROFILE_CAPTURE_VOCAB[AI_ASSISTED_ANALYSIS_PROFILE_TYPE],
+    'must be the same array object — re-exported, not copied',
+  );
+  assert.deepEqual(AI_ASSISTED_ANALYSIS_CAPTURE_METHODS, [
+    'chat-flow-stream',
+    'claude-code-jsonl-readback',
+    'claude-code-self-report',
+  ]);
+});

--- a/packages/civic-typed-harness/src/format/profiles.ts
+++ b/packages/civic-typed-harness/src/format/profiles.ts
@@ -1,0 +1,31 @@
+// captureMethod vocabulary surface (FORMAT-EXTENSION group) — the profile
+// constants the civic harness publishes under, re-exported CONSISTENT WITH
+// verify-core's hardcoded fallback table by construction (the values below
+// ARE that table's entry, not a copy).
+//
+// ⚠ Q32 adjacency (open-questions registry): verify-core's per-profile
+// captureMethod vocabulary is a hardcoded fallback table pending versioned,
+// content-addressed guidance bundles. The `ai-assisted-analysis` guidance
+// bundle already lives in civic-ai-tools docs (ADR-0006/ADR-0011), which is
+// one more reason the Q32 versioned-bundle question eventually lands in this
+// package. Flagged, not solved, here — do not grow this module into a bundle
+// mechanism without resolving Q32 first.
+
+import { PROFILE_CAPTURE_VOCAB } from '@typedstandards/verify-core';
+import type { CaptureMethod } from '@typedstandards/verify-core';
+
+export type { CaptureMethod };
+
+/** The profile TYPE the civic harness publishes under (the segment before the
+ *  first `/` of the compound producerProfile). */
+export const AI_ASSISTED_ANALYSIS_PROFILE_TYPE = 'ai-assisted-analysis';
+
+/**
+ * The captureMethod vocabulary for the `ai-assisted-analysis` profile type —
+ * verify-core's Q32 fallback-table entry, re-exported (single-sourced, so the
+ * harness cannot drift from what the verifier accepts):
+ * `chat-flow-stream` · `claude-code-jsonl-readback` ·
+ * `claude-code-self-report` (legacy, deprecated 2026-04-28).
+ */
+export const AI_ASSISTED_ANALYSIS_CAPTURE_METHODS: readonly CaptureMethod[] =
+  PROFILE_CAPTURE_VOCAB[AI_ASSISTED_ANALYSIS_PROFILE_TYPE];

--- a/packages/civic-typed-harness/src/format/sources.test.ts
+++ b/packages/civic-typed-harness/src/format/sources.test.ts
@@ -1,0 +1,177 @@
+// Source-registry tests: the civic default registry's coordinates, the
+// default tool→source resolver, and the display helpers ported from the
+// reference data-sources test suite.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import type { DataSourceEntry } from '@typedstandards/produce-core';
+import {
+  CIVIC_SOURCE_REGISTRY,
+  CIVIC_TOOL_SOURCE_MAP,
+  FALLBACK_SOURCE_ID,
+  civicToolSourceResolver,
+  isDatasetKeyedSource,
+  displayNameForSource,
+  formatDataSourcesSummary,
+} from './sources.ts';
+
+const NOW = '2026-04-16T00:00:00.000Z';
+
+test('civic registry: three demo sources with reference coordinates', () => {
+  assert.deepEqual(Object.keys(CIVIC_SOURCE_REGISTRY), [
+    'socrata',
+    'data-commons',
+    'boston-opencontext',
+  ]);
+  assert.equal(CIVIC_SOURCE_REGISTRY.socrata.serverUrl, 'https://socrata-mcp.civicaitools.org');
+  assert.equal(CIVIC_SOURCE_REGISTRY['data-commons'].serverUrl, 'https://api.datacommons.org/mcp');
+  assert.equal(
+    CIVIC_SOURCE_REGISTRY['boston-opencontext'].serverUrl,
+    'https://data-mcp.boston.gov/mcp',
+  );
+  assert.equal(
+    CIVIC_SOURCE_REGISTRY['boston-opencontext'].aggregatePortalUrl,
+    'https://data.boston.gov',
+  );
+  assert.equal(FALLBACK_SOURCE_ID, 'socrata');
+});
+
+test('dataset-keyed split: socrata is dataset-keyed; DC and Boston are aggregate; unknown is neither', () => {
+  assert.equal(isDatasetKeyedSource('socrata'), true);
+  assert.equal(isDatasetKeyedSource('data-commons'), false);
+  assert.equal(isDatasetKeyedSource('boston-opencontext'), false);
+  assert.equal(isDatasetKeyedSource('eurostat'), false);
+});
+
+test('default resolver mirrors the demo MCP tool names', () => {
+  assert.equal(civicToolSourceResolver('get_data'), 'socrata');
+  assert.equal(civicToolSourceResolver('search'), 'socrata');
+  assert.equal(civicToolSourceResolver('fetch'), 'socrata');
+  assert.equal(civicToolSourceResolver('search_indicators'), 'data-commons');
+  assert.equal(civicToolSourceResolver('get_observations'), 'data-commons');
+  assert.equal(civicToolSourceResolver('ckan__aggregate_data'), 'boston-opencontext');
+  assert.equal(civicToolSourceResolver('mystery_tool'), undefined);
+  // Every mapped source id exists in the registry.
+  for (const sourceId of Object.values(CIVIC_TOOL_SOURCE_MAP)) {
+    assert.ok(CIVIC_SOURCE_REGISTRY[sourceId], `unmapped source id: ${sourceId}`);
+  }
+});
+
+// --- Display helpers (ported from the reference test suite) ---
+
+test('displayNameForSource maps known source ids to friendly names', () => {
+  assert.equal(displayNameForSource('socrata'), 'Socrata');
+  assert.equal(displayNameForSource('data-commons'), 'Data Commons');
+  assert.equal(displayNameForSource('boston-opencontext'), 'Boston OpenContext');
+});
+
+test('displayNameForSource capitalises unknown ids so new sources render sensibly', () => {
+  assert.equal(displayNameForSource('boston-core'), 'Boston Core');
+  assert.equal(displayNameForSource('eurostat'), 'Eurostat');
+});
+
+test('displayNameForSource coerces missing sourceId to Socrata (pre-M9.3 packages)', () => {
+  assert.equal(displayNameForSource(undefined), 'Socrata');
+  assert.equal(displayNameForSource(null), 'Socrata');
+  assert.equal(displayNameForSource(''), 'Socrata');
+});
+
+test('displayNameForSource honors a caller-supplied registry', () => {
+  const registry = {
+    'city-warehouse': {
+      displayName: 'City Warehouse',
+      agentTitle: 'City Warehouse MCP Server',
+      serverUrl: 'https://mcp.city.example',
+      catalogType: 'warehouse',
+    },
+  };
+  assert.equal(displayNameForSource('city-warehouse', registry), 'City Warehouse');
+});
+
+test('formatDataSourcesSummary returns null for missing or empty arrays', () => {
+  assert.equal(formatDataSourcesSummary(undefined), null);
+  assert.equal(formatDataSourcesSummary([]), null);
+});
+
+test('formatDataSourcesSummary renders single-source DC package without Socrata leakage', () => {
+  const entries: DataSourceEntry[] = [
+    {
+      sourceId: 'data-commons',
+      catalogType: 'data-commons',
+      portalUrl: 'https://api.datacommons.org/mcp',
+      accessTimestamp: NOW,
+    },
+  ];
+  assert.equal(formatDataSourcesSummary(entries), 'Data Commons');
+});
+
+test('formatDataSourcesSummary dedupes multiple Socrata dataset entries into one name', () => {
+  const entries: DataSourceEntry[] = [
+    {
+      sourceId: 'socrata',
+      catalogType: 'socrata',
+      portalUrl: 'https://data.cityofnewyork.us',
+      datasetId: 'erm2-nwe9',
+      datasetUrl: 'https://data.cityofnewyork.us/d/erm2-nwe9',
+      accessTimestamp: NOW,
+    },
+    {
+      sourceId: 'socrata',
+      catalogType: 'socrata',
+      portalUrl: 'https://data.cityofnewyork.us',
+      datasetId: '43nn-pn8j',
+      datasetUrl: 'https://data.cityofnewyork.us/d/43nn-pn8j',
+      accessTimestamp: NOW,
+    },
+  ];
+  assert.equal(formatDataSourcesSummary(entries), 'Socrata');
+});
+
+test('formatDataSourcesSummary joins multi-source entries with a middle-dot separator', () => {
+  const entries: DataSourceEntry[] = [
+    {
+      sourceId: 'socrata',
+      catalogType: 'socrata',
+      portalUrl: 'https://data.cityofnewyork.us',
+      datasetId: 'erm2-nwe9',
+      datasetUrl: 'https://data.cityofnewyork.us/d/erm2-nwe9',
+      accessTimestamp: NOW,
+    },
+    {
+      sourceId: 'data-commons',
+      catalogType: 'data-commons',
+      portalUrl: 'https://api.datacommons.org/mcp',
+      accessTimestamp: NOW,
+    },
+  ];
+  assert.equal(formatDataSourcesSummary(entries), 'Socrata · Data Commons');
+});
+
+test('formatDataSourcesSummary renders a three-source analysis in active-source order', () => {
+  const entries: DataSourceEntry[] = [
+    {
+      sourceId: 'socrata',
+      catalogType: 'socrata',
+      portalUrl: 'https://data.cityofnewyork.us',
+      datasetId: 'erm2-nwe9',
+      datasetUrl: 'https://data.cityofnewyork.us/d/erm2-nwe9',
+      accessTimestamp: NOW,
+    },
+    {
+      sourceId: 'data-commons',
+      catalogType: 'data-commons',
+      portalUrl: 'https://api.datacommons.org/mcp',
+      accessTimestamp: NOW,
+    },
+    {
+      sourceId: 'boston-opencontext',
+      catalogType: 'ckan',
+      portalUrl: 'https://data.boston.gov',
+      accessTimestamp: NOW,
+    },
+  ];
+  assert.equal(
+    formatDataSourcesSummary(entries),
+    'Socrata · Data Commons · Boston OpenContext',
+  );
+});

--- a/packages/civic-typed-harness/src/format/sources.ts
+++ b/packages/civic-typed-harness/src/format/sources.ts
@@ -1,0 +1,145 @@
+// Civic data-source registry (FORMAT-EXTENSION group) — the source ids the
+// civic vocabulary knows, their display names, catalog types, and endpoint
+// coordinates, plus the default tool-name → source-id resolver and the
+// display helpers. Relocated from civic-ai-tools-website:
+//   - endpoint constants + display helpers: `src/lib/evidence/data-sources.ts:15–16, 41–76`
+//   - agent titles/server URLs: `src/lib/evidence/provenance.ts:132–148`
+//   - static tool→source map: `src/lib/mcp/operation-types.ts:21–33` (the
+//     app's MCP registry itself stays app-side; this is the harness's civic
+//     DEFAULT — callers supply their own resolver to add or replace sources).
+//
+// Endpoint URLs name the demo deployment's data plane, so the registry is a
+// typed config input (config-not-constants, S2 brief §2) with the civic
+// values as the exported default map.
+
+import type { DataSourceEntry } from '@typedstandards/produce-core';
+
+/** One known data source: identity, display, and endpoint coordinates. */
+export interface CivicSourceInfo {
+  /** Human-friendly display label (evidence detail page "Data sources"). */
+  displayName: string;
+  /** PROV agent `dcterms:title`, e.g. "Socrata MCP Server". */
+  agentTitle: string;
+  /** MCP endpoint URL — the PROV agent's `civic:serverUrl`. */
+  serverUrl: string;
+  /** `dataSources[].catalogType` value for entries from this source. */
+  catalogType: string;
+  /**
+   * Portal URL for the single AGGREGATE `dataSources` entry emitted when this
+   * source's query surface is not dataset-keyed (Data Commons's knowledge
+   * graph, Boston OpenContext's CKAN DataStore). ABSENT for dataset-keyed
+   * sources (Socrata), which emit one entry per dataset instead — presence of
+   * this field is what routes a source down the aggregate path.
+   */
+  aggregatePortalUrl?: string;
+}
+
+/** A source registry: source id → coordinates. Insertion order is emission
+ *  order for aggregate `dataSources` entries. */
+export type CivicSourceRegistry = Record<string, CivicSourceInfo>;
+
+/** The civic default registry — the three demo sources. */
+export const CIVIC_SOURCE_REGISTRY: CivicSourceRegistry = {
+  socrata: {
+    displayName: 'Socrata',
+    agentTitle: 'Socrata MCP Server',
+    serverUrl: 'https://socrata-mcp.civicaitools.org',
+    catalogType: 'socrata',
+  },
+  'data-commons': {
+    displayName: 'Data Commons',
+    agentTitle: 'Google Data Commons MCP Server',
+    serverUrl: 'https://api.datacommons.org/mcp',
+    catalogType: 'data-commons',
+    aggregatePortalUrl: 'https://api.datacommons.org/mcp',
+  },
+  'boston-opencontext': {
+    displayName: 'Boston OpenContext',
+    agentTitle: 'Boston OpenContext MCP Server',
+    serverUrl: 'https://data-mcp.boston.gov/mcp',
+    catalogType: 'ckan',
+    aggregatePortalUrl: 'https://data.boston.gov',
+  },
+};
+
+/** The source id untagged/pre-M9.1 captures fall back to. Socrata was the
+ *  only source when those packages were written. */
+export const FALLBACK_SOURCE_ID = 'socrata';
+
+/** Is this source dataset-keyed (one `dataSources` entry per dataset) rather
+ *  than aggregate? Unknown ids are neither — they contribute no entry. */
+export function isDatasetKeyedSource(
+  sourceId: string,
+  registry: CivicSourceRegistry = CIVIC_SOURCE_REGISTRY,
+): boolean {
+  const info = registry[sourceId];
+  return info !== undefined && info.aggregatePortalUrl === undefined;
+}
+
+/**
+ * Resolve an MCP tool name to a source id, or `undefined` when unknown.
+ * The data-source population function (capture group) takes one of these as
+ * a CALLER-SUPPLIED input; `civicToolSourceResolver` below is the civic
+ * default. An instance wiring its own MCP layer supplies its own resolver —
+ * the resolver is how the app-side MCP registry stays app-side.
+ */
+export type ToolSourceResolver = (toolName: string) => string | undefined;
+
+/** Civic default tool-name → source-id map (mirrors the demo app's static
+ *  MCP-layer map; used as a fallback when a trace span carries no
+ *  `mcp.source` attribute). */
+export const CIVIC_TOOL_SOURCE_MAP: Record<string, string> = {
+  get_data: 'socrata',
+  search: 'socrata',
+  fetch: 'socrata',
+  search_indicators: 'data-commons',
+  get_observations: 'data-commons',
+  ckan__search_datasets: 'boston-opencontext',
+  ckan__get_dataset: 'boston-opencontext',
+  ckan__query_data: 'boston-opencontext',
+  ckan__get_schema: 'boston-opencontext',
+  ckan__execute_sql: 'boston-opencontext',
+  ckan__aggregate_data: 'boston-opencontext',
+};
+
+/** The civic default `ToolSourceResolver`. */
+export const civicToolSourceResolver: ToolSourceResolver = (toolName) =>
+  CIVIC_TOOL_SOURCE_MAP[toolName];
+
+/** Human-friendly display label for a `sourceId`. Unknown ids fall back to a
+ *  capitalised form of the raw id so new sources render sensibly before the
+ *  registry is updated. Missing ids coerce to the fallback source (pre-M9.3
+ *  packages have no `sourceId` on dataSources entries). */
+export function displayNameForSource(
+  sourceId: string | undefined | null,
+  registry: CivicSourceRegistry = CIVIC_SOURCE_REGISTRY,
+): string {
+  const id = sourceId || FALLBACK_SOURCE_ID;
+  return (
+    registry[id]?.displayName
+    ?? id
+      .split('-')
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(' ')
+  );
+}
+
+/** Format a `dataSources` array as a compact, de-duplicated summary string
+ *  (middle-dot separated). Returns `null` when the array is empty or missing,
+ *  letting callers render a fallback. */
+export function formatDataSourcesSummary(
+  entries: DataSourceEntry[] | undefined,
+  registry: CivicSourceRegistry = CIVIC_SOURCE_REGISTRY,
+): string | null {
+  if (!entries || entries.length === 0) return null;
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const entry of entries) {
+    const name = displayNameForSource(entry.sourceId, registry);
+    if (seen.has(name)) continue;
+    seen.add(name);
+    ordered.push(name);
+  }
+  return ordered.join(' · ');
+}

--- a/packages/civic-typed-harness/src/format/vocabulary.ts
+++ b/packages/civic-typed-harness/src/format/vocabulary.ts
@@ -1,0 +1,76 @@
+// Civic PROV-O vocabulary (FORMAT-EXTENSION group) — the `civic:` JSON-LD
+// namespace, the `urn:civic-evidence:` id scheme, and the platform-agent
+// identity shape. Relocated from civic-ai-tools-website
+// `src/lib/evidence/provenance.ts` (`:51` urn scheme, `:179–184` platform
+// agent, `:384–391` context) per the S2 brief §1.
+//
+// This module defines vocabulary; it never walks a trace. The capture-side
+// provenance BUILDER (src/capture/provenance.ts) imports its terms from here —
+// that direction is the package's internal module boundary.
+
+import { makeProvContext, PROV_NS, XSD_NS, DCTERMS_NS } from '@typedstandards/produce-core';
+
+/** The `civic:` JSON-LD namespace URI. Part of the civic vocabulary itself
+ *  (it names the term set, not a deployment), so it is a constant, not a
+ *  config input. */
+export const CIVIC_NS = 'https://civicaitools.org/ns/evidence/';
+
+/** The civic evidence-package JSON-LD `@context`: prov / xsd / civic /
+ *  dcterms, in the reference emission order (legacy-chain byte discipline —
+ *  insertion order is the byte contract). */
+export function makeCivicProvContext(): Record<string, string> {
+  return makeProvContext({
+    prov: PROV_NS,
+    xsd: XSD_NS,
+    civic: CIVIC_NS,
+    dcterms: DCTERMS_NS,
+  });
+}
+
+/** Root of the `urn:civic-evidence:` id scheme. */
+export const CIVIC_URN_PREFIX = 'urn:civic-evidence';
+
+/** Package-scoped node id: `urn:civic-evidence:<packageId>:<type>:<id>`. */
+export function civicUrn(packageId: string, type: string, id: string): string {
+  return `${CIVIC_URN_PREFIX}:${packageId}:${type}:${id}`;
+}
+
+/** Model-agent id: `urn:civic-evidence:model:<modelId>` (slashes in the
+ *  model identifier collapse to dashes). */
+export function civicModelUrn(model: string): string {
+  return `${CIVIC_URN_PREFIX}:model:${model.replace(/\//g, '-')}`;
+}
+
+/** MCP source-agent id: `urn:civic-evidence:mcp-server:<sourceId>`. Known
+ *  source ids are emitted raw (they are already URN-safe by construction);
+ *  callers emitting an UNKNOWN id must encode it first (the capture-side
+ *  builder uses `encodeURIComponent`, matching the reference behavior). */
+export function civicSourceAgentUrn(sourceId: string): string {
+  return `${CIVIC_URN_PREFIX}:mcp-server:${sourceId}`;
+}
+
+/** Platform-agent id: `urn:civic-evidence:platform:<platformId>`. */
+export function civicPlatformUrn(platformId: string): string {
+  return `${CIVIC_URN_PREFIX}:platform:${platformId}`;
+}
+
+/**
+ * Platform-agent identity — WHO published, as a PROV agent. A typed config
+ * input (config-not-constants, S2 brief §2): every deployment names its own;
+ * the civicaitools.org demo values are the exported default below.
+ */
+export interface PlatformAgentConfig {
+  /** Stable platform id — becomes `urn:civic-evidence:platform:<id>`. */
+  id: string;
+  /** Human-readable platform title (`dcterms:title`). */
+  title: string;
+  /** Public URL of the deployment (`civic:url`). */
+  url: string;
+}
+
+/** Demo default: the civicaitools.org reference deployment's identity. */
+export const CIVICAITOOLS_PLATFORM_AGENT: PlatformAgentConfig = {
+  id: 'civic-ai-tools',
+  title: 'Civic AI Tools',
+  url: 'https://civicaitools.org',
+};

--- a/packages/civic-typed-harness/src/index.ts
+++ b/packages/civic-typed-harness/src/index.ts
@@ -1,0 +1,33 @@
+// civic-typed-harness — the civic DOMAIN layer of ADR-0021's format/domain
+// line, relocated from the reference app (civic-ai-tools-website) per the S2
+// brief. The operating rule: THE HARNESS DERIVES, THE CORE ASSEMBLES — every
+// export here produces domain-derived values (vocabulary terms, datHere
+// policy fields, provenance graphs, capture artifacts) that feed
+// @typedstandards/produce-core's neutral envelope assembly.
+//
+// Internal module boundary (structure-for-the-future; see README):
+//   - format/  — the civic FORMAT-EXTENSION: what extends the standard
+//     (civic: vocabulary, source registry, datHere policy, profile constants).
+//   - capture/ — what PRODUCES under it: TraceBuilder, skill-metadata
+//     extraction, data-source population, and the provenance BUILDER (which
+//     imports its vocabulary from format/). Clock + RNG live here only.
+//   - rubric/  — the adversarial-evaluation pure core (Q26-pinned hash).
+//
+// Purity contract (harness-grade): no I/O and no environment reads anywhere;
+// clock + RNG permitted in capture modules only and injectable for tests.
+// Enforced by eslint.config.mjs and src/purity.test.ts.
+
+// Format-extension group
+export * from './format/vocabulary.ts';
+export * from './format/sources.ts';
+export * from './format/dathere.ts';
+export * from './format/profiles.ts';
+
+// Capture group
+export * from './capture/trace.ts';
+export * from './capture/skill-metadata.ts';
+export * from './capture/data-sources.ts';
+export * from './capture/provenance.ts';
+
+// Rubric group
+export * from './rubric/adversarial-eval-core.ts';

--- a/packages/civic-typed-harness/src/purity.test.ts
+++ b/packages/civic-typed-harness/src/purity.test.ts
@@ -1,0 +1,171 @@
+// Purity + module-boundary guard for civic-typed-harness (mirrors
+// produce-core's browser-safety guard, adapted to the harness-grade contract
+// of the S2 brief §2).
+//
+// Contract enforced here, mechanically, on every shipped source file:
+//   1. Browser safety (whole package): no Node built-in imports, no Buffer.
+//   2. No environment reads (whole package): configuration is caller-supplied.
+//   3. Determinism (format-extension + rubric + index): no clock, no RNG.
+//      Capture modules (src/capture/**) are the sanctioned exception — span
+//      timestamps and ids are what capture *is* — and both are injectable.
+//   4. Internal module boundary (structure-for-the-future):
+//      - format-extension and rubric modules never import from capture;
+//      - capture modules never DEFINE civic vocabulary (the `urn:` scheme,
+//        the civic namespace, the datHere profile string live in format/);
+//      - format-extension modules never WALK a trace.
+// Test files are exempt: they legitimately use node:test / node:fs / node:crypto.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, relative } from 'node:path';
+
+const SRC_DIR = dirname(fileURLToPath(import.meta.url));
+
+function shippedSourceFiles(dir = SRC_DIR): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__fixtures__' || entry.name === 'node_modules') continue;
+      out.push(...shippedSourceFiles(full));
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function rel(file: string): string {
+  return relative(SRC_DIR, file);
+}
+
+// Specifiers a browser-safe module must never import. `Buffer` is a global,
+// not an import, so it is checked separately below.
+const FORBIDDEN_SPECIFIERS = [
+  'node:crypto',
+  'crypto',
+  'node:fs',
+  'fs',
+  'node:fs/promises',
+  'fs/promises',
+  'node:path',
+  'path',
+  'node:process',
+  'process',
+  'node:os',
+  'node:url',
+  'node:util',
+];
+
+// Match the module specifier of any static/dynamic import or re-export.
+const IMPORT_RE = /(?:import|export)\s[^'"`]*?from\s*['"]([^'"`]+)['"]|import\s*\(\s*['"]([^'"`]+)['"]\s*\)/g;
+
+test('browser-safety: no shipped source imports a Node built-in', () => {
+  const files = shippedSourceFiles();
+  assert.ok(files.length > 5, 'expected to find the harness source files');
+
+  for (const file of files) {
+    const code = readFileSync(file, 'utf8');
+    for (const m of code.matchAll(IMPORT_RE)) {
+      const spec = m[1] ?? m[2] ?? '';
+      assert.ok(
+        !FORBIDDEN_SPECIFIERS.includes(spec) && !spec.startsWith('node:'),
+        `${rel(file)} imports "${spec}" — the harness must stay browser-safe (use verify-core primitives and keep I/O caller-side).`,
+      );
+    }
+  }
+});
+
+// Match actual Buffer *usage*, not the bare word (comments may mention it).
+const BUFFER_USE_RE = /\bnew\s+Buffer\b|\bBuffer\s*[.(]/;
+
+test('browser-safety: no shipped source uses the Buffer global', () => {
+  for (const file of shippedSourceFiles()) {
+    const code = readFileSync(file, 'utf8');
+    assert.ok(
+      !BUFFER_USE_RE.test(code),
+      `${rel(file)} uses Buffer — use atob / btoa / Uint8Array / verify-core primitives instead.`,
+    );
+  }
+});
+
+test('no environment reads anywhere in shipped source', () => {
+  const ENV_RE = /\bprocess\s*\.\s*env\b/;
+  for (const file of shippedSourceFiles()) {
+    const code = readFileSync(file, 'utf8');
+    assert.ok(
+      !ENV_RE.test(code),
+      `${rel(file)} reads process.env — instance values are typed config inputs with exported demo defaults.`,
+    );
+  }
+});
+
+// Determinism guard for the NON-CAPTURE groups: format-extension, rubric, and
+// the index must not read a clock or an RNG. Capture modules are exempt —
+// clock/RNG are inherent to capture and injectable for tests.
+const NONDETERMINISM_RE =
+  /\bDate\.now\s*\(|\bnew\s+Date\s*\(|\bMath\.random\s*\(|\brandomUUID\s*\(|\bgetRandomValues\s*\(/;
+
+test('determinism: no non-capture shipped source reads a clock or an RNG', () => {
+  const nonCapture = shippedSourceFiles().filter(
+    (f) => !rel(f).startsWith('capture/'),
+  );
+  assert.ok(nonCapture.length >= 5, 'expected the format/rubric/index files');
+  for (const file of nonCapture) {
+    const code = readFileSync(file, 'utf8');
+    assert.ok(
+      !NONDETERMINISM_RE.test(code),
+      `${rel(file)} reads a clock/RNG — that is capture-only (src/capture/**), injectable for tests.`,
+    );
+  }
+});
+
+// --- Internal module boundary (S2 brief §2) ---
+
+test('boundary: format-extension and rubric modules never import from capture', () => {
+  const nonCapture = shippedSourceFiles().filter(
+    (f) => rel(f).startsWith('format/') || rel(f).startsWith('rubric/'),
+  );
+  for (const file of nonCapture) {
+    const code = readFileSync(file, 'utf8');
+    for (const m of code.matchAll(IMPORT_RE)) {
+      const spec = m[1] ?? m[2] ?? '';
+      assert.ok(
+        !/(^|\/)capture\//.test(spec),
+        `${rel(file)} imports "${spec}" — the format-extension/rubric groups must not depend on capture (the future package split runs along this line).`,
+      );
+    }
+  }
+});
+
+test('boundary: capture modules define no civic vocabulary (terms live in format/)', () => {
+  const VOCAB_LITERALS = [
+    'urn:civic-evidence', // the id scheme
+    'civicaitools.org/ns/evidence', // the civic: namespace
+    'ai-assisted-analysis/datHere', // the datHere producer profile
+  ];
+  for (const file of shippedSourceFiles().filter((f) => rel(f).startsWith('capture/'))) {
+    const code = readFileSync(file, 'utf8');
+    for (const literal of VOCAB_LITERALS) {
+      assert.ok(
+        !code.includes(literal),
+        `${rel(file)} contains the vocabulary literal "${literal}" — capture modules import vocabulary from the format-extension group, never define it.`,
+      );
+    }
+  }
+});
+
+test('boundary: format-extension modules never walk a trace', () => {
+  const TRACE_WALK_LITERALS = ['resourceSpans', 'scopeSpans', 'mcp_tool_call', 'skill_fetch'];
+  for (const file of shippedSourceFiles().filter((f) => rel(f).startsWith('format/'))) {
+    const code = readFileSync(file, 'utf8');
+    for (const literal of TRACE_WALK_LITERALS) {
+      assert.ok(
+        !code.includes(literal),
+        `${rel(file)} references "${literal}" — trace walking is capture-group work; format-extension modules carry vocabulary and policy only.`,
+      );
+    }
+  }
+});

--- a/packages/civic-typed-harness/src/rubric/adversarial-eval-core.test.ts
+++ b/packages/civic-typed-harness/src/rubric/adversarial-eval-core.test.ts
@@ -1,0 +1,136 @@
+// Adversarial-eval pure-core tests, ported from the reference suite, plus the
+// load-bearing relocation check: RUBRIC_VERSION_SHA256 is a Q26-pinned
+// version hash and MUST be byte-exact with the reference implementation —
+// the literal below was captured from civic-ai-tools-website
+// src/lib/evidence/adversarial-eval-core.ts on 2026-08-01.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import {
+  EVALUATION_RUBRIC,
+  EVALUATION_CRITERIA,
+  RUBRIC_ID,
+  RUBRIC_VERSION_SHA256,
+  buildEvaluationPrompt,
+  parseEvaluationResponse,
+} from './adversarial-eval-core.ts';
+import type { EvidencePackage } from '@typedstandards/produce-core';
+
+/** The reference implementation's rubric version hash. Byte-exact preservation
+ *  is a G0 decision (decision 4): moving the rubric changes no hashes. */
+const REFERENCE_RUBRIC_VERSION_SHA256 =
+  'b62b193c992fd430cc82dff9a80a057bbe0b2b656fbdace450ca1a5d99fffa02';
+
+function validResponse(overrides: Record<string, unknown> = {}): string {
+  const base: Record<string, unknown> = Object.fromEntries(
+    EVALUATION_CRITERIA.map((k, i) => [k, { score: i + 4, comment: `note ${k}` }]),
+  );
+  return JSON.stringify({
+    ...base,
+    overallScore: 6.5,
+    assessment: 'A reasonable analysis with caveats.',
+    ...overrides,
+  });
+}
+
+test('RUBRIC_VERSION_SHA256 is byte-exact with the reference implementation', () => {
+  assert.equal(RUBRIC_VERSION_SHA256, REFERENCE_RUBRIC_VERSION_SHA256);
+});
+
+test('RUBRIC_VERSION_SHA256 pins the exact rubric text (noble backend matches node:crypto)', () => {
+  const expected = crypto.createHash('sha256').update(EVALUATION_RUBRIC).digest('hex');
+  assert.equal(RUBRIC_VERSION_SHA256, expected);
+  assert.equal(RUBRIC_VERSION_SHA256.length, 64);
+  assert.ok(RUBRIC_ID.startsWith('civicaitools-adversarial-rubric/'));
+});
+
+test('parseEvaluationResponse: accepts a conformant response', () => {
+  const parsed = parseEvaluationResponse(validResponse());
+  assert.ok(parsed.ok);
+  if (parsed.ok) {
+    assert.equal(parsed.results.overallScore, 6.5);
+    assert.equal(parsed.results.assessment, 'A reasonable analysis with caveats.');
+    assert.equal(Object.keys(parsed.results.perCriterion).length, EVALUATION_CRITERIA.length);
+    assert.equal(parsed.results.perCriterion.dataSourceIdentification.score, 4);
+  }
+});
+
+test('parseEvaluationResponse: strips markdown fences', () => {
+  const fenced = '```json\n' + validResponse() + '\n```';
+  const parsed = parseEvaluationResponse(fenced);
+  assert.ok(parsed.ok);
+});
+
+test('parseEvaluationResponse: recomputes overallScore when omitted', () => {
+  const obj = JSON.parse(validResponse());
+  delete obj.overallScore;
+  const parsed = parseEvaluationResponse(JSON.stringify(obj));
+  assert.ok(parsed.ok);
+  if (parsed.ok) {
+    // scores are 4..9 → mean 6.5
+    assert.equal(parsed.results.overallScore, 6.5);
+  }
+});
+
+test('parseEvaluationResponse: rejects invalid JSON with the raw text preserved', () => {
+  const parsed = parseEvaluationResponse('I cannot evaluate this.');
+  assert.ok(!parsed.ok);
+  if (!parsed.ok) {
+    assert.equal(parsed.error, 'Evaluator returned invalid JSON');
+    assert.equal(parsed.raw, 'I cannot evaluate this.');
+  }
+});
+
+test('parseEvaluationResponse: rejects a missing criterion by name', () => {
+  const obj = JSON.parse(validResponse());
+  delete obj.geographicScope;
+  const parsed = parseEvaluationResponse(JSON.stringify(obj));
+  assert.ok(!parsed.ok);
+  if (!parsed.ok) {
+    assert.match(parsed.error, /geographicScope/);
+  }
+});
+
+test('parseEvaluationResponse: rejects a non-numeric score', () => {
+  const obj = JSON.parse(validResponse());
+  obj.limitationsNoted = { score: 'high', comment: 'x' };
+  const parsed = parseEvaluationResponse(JSON.stringify(obj));
+  assert.ok(!parsed.ok);
+});
+
+test('buildEvaluationPrompt: includes prompt text, tool calls, and output', () => {
+  const pkg = {
+    prompt: { text: 'How many noise complaints?', hash: 'h', visibility: 'full_text' },
+    queries: [
+      {
+        tool: 'get_data',
+        operationType: 'query',
+        arguments: { dataset_id: 'erm2-nwe9' },
+        resultRows: 12,
+      },
+    ],
+    dataSources: [
+      { datasetUrl: 'https://data.example/d/erm2-nwe9', accessTimestamp: '2026-06-12T00:00:00Z' },
+    ],
+    cost: { model: 'openai/gpt-4o' },
+    output: 'There were 12 complaints.',
+  } as unknown as EvidencePackage;
+  const prompt = buildEvaluationPrompt(pkg);
+  assert.match(prompt, /How many noise complaints\?/);
+  assert.match(prompt, /get_data\(dataset_id="erm2-nwe9"\) → 12 rows/);
+  assert.match(prompt, /https:\/\/data\.example\/d\/erm2-nwe9/);
+  assert.match(prompt, /There were 12 complaints\./);
+  assert.match(prompt, /openai\/gpt-4o/);
+});
+
+test('buildEvaluationPrompt: hash-only prompts render the unavailable marker', () => {
+  const pkg = {
+    prompt: { hash: 'h', visibility: 'hash_only' },
+    queries: [],
+    dataSources: [],
+    cost: { model: 'm' },
+    output: 'out',
+  } as unknown as EvidencePackage;
+  assert.match(buildEvaluationPrompt(pkg), /\[prompt text not available\]/);
+});

--- a/packages/civic-typed-harness/src/rubric/adversarial-eval-core.ts
+++ b/packages/civic-typed-harness/src/rubric/adversarial-eval-core.ts
@@ -1,0 +1,148 @@
+// Adversarial evaluation — PURE core (RUBRIC group): the civic six-criterion
+// rubric text, its pinned identifiers, the prompt builder, and the response
+// parser. Relocated from civic-ai-tools-website
+// `src/lib/evidence/adversarial-eval-core.ts:13, 24–55, 66–94` per the S2
+// brief §1. The model runner and DB/blob emission (`adversarial-eval.ts`)
+// stay app-side — this module never performs I/O.
+//
+// ⚠ RUBRIC_VERSION_SHA256 is a Q26-pinned version hash: attestations pin the
+// exact prompt set that scored them by this value. The rubric text below is
+// byte-exact with the reference implementation (the relocation changes no
+// hashes), and the test suite asserts the literal digest. Any wording change
+// to EVALUATION_RUBRIC is a NEW rubric version — never edit the text without
+// versioning intent.
+
+import { sha256Hex } from '@typedstandards/verify-core';
+import type { EvidencePackage, EvaluationResults } from '@typedstandards/produce-core';
+
+/** Rubric identifier carried as the `scoringRubric` payload field and the
+ *  methodology `testSet`. Six criteria, 1-10 each, plus aggregate. */
+export const RUBRIC_ID = 'civicaitools-adversarial-rubric/six-criterion-v1';
+
+export const EVALUATION_CRITERIA = [
+  'dataSourceIdentification',
+  'quantitativeClaimSupport',
+  'confoundersAndBias',
+  'geographicScope',
+  'limitationsNoted',
+  'contradictoryConclusion',
+] as const;
+
+export const EVALUATION_RUBRIC = `You are an independent evaluator assessing an AI-generated civic data analysis.
+
+You will receive:
+1. The original prompt (question asked)
+2. The tool calls made (MCP queries to Socrata open data portals)
+3. The AI's final output/analysis
+
+Evaluate the analysis against these 6 criteria, scoring each 1-10:
+
+a) **Data Source Identification** (1-10): Does the output correctly identify the data source(s) and time period? Are dataset IDs, portal domains, and date ranges accurate?
+
+b) **Quantitative Claim Support** (1-10): Are the quantitative claims (numbers, percentages, rankings) supported by the data returned in the tool calls? Cross-check key figures against the raw data.
+
+c) **Confounders and Bias** (1-10): Does the analysis acknowledge obvious confounders, selection biases, or framing issues? Are there lurking variables or cherry-picked timeframes?
+
+d) **Geographic Scope** (1-10): Is the geographic scope appropriate for the question? Does the analysis avoid over-generalizing from one jurisdiction?
+
+e) **Limitations Noted** (1-10): Are limitations and caveats noted? Does the analysis flag data quality issues, missing fields, or incomplete coverage?
+
+f) **Contradictory Conclusion** (1-10): Could the same data reasonably support a contradictory conclusion? Does the analysis consider alternative interpretations?
+
+Respond in this exact JSON format (no markdown fences, just raw JSON):
+{
+  "dataSourceIdentification": { "score": <1-10>, "comment": "<1-2 sentences>" },
+  "quantitativeClaimSupport": { "score": <1-10>, "comment": "<1-2 sentences>" },
+  "confoundersAndBias": { "score": <1-10>, "comment": "<1-2 sentences>" },
+  "geographicScope": { "score": <1-10>, "comment": "<1-2 sentences>" },
+  "limitationsNoted": { "score": <1-10>, "comment": "<1-2 sentences>" },
+  "contradictoryConclusion": { "score": <1-10>, "comment": "<1-2 sentences>" },
+  "overallScore": <average of all 6 scores, one decimal>,
+  "assessment": "<2-4 sentence overall assessment>"
+}`;
+
+/** The methodology's `promptSetVersion`: SHA-256 of the rubric text, computed
+ *  once at module load. Any wording change to the rubric produces a new
+ *  version, so an attestation pins the exact prompt set that scored it. */
+export const RUBRIC_VERSION_SHA256 = sha256Hex(EVALUATION_RUBRIC);
+
+/** Build the user-turn evaluation content from a package's signed fields. */
+export function buildEvaluationPrompt(pkg: EvidencePackage): string {
+  const toolCallSummary = pkg.queries
+    .map((q, i) => {
+      const argStr = Object.entries(q.arguments)
+        .map(([k, v]) => `${k}=${JSON.stringify(v)}`)
+        .join(', ');
+      return `  ${i + 1}. ${q.tool}(${argStr}) → ${q.resultRows ?? '?'} rows`;
+    })
+    .join('\n');
+
+  const dataSources = pkg.dataSources
+    .map(ds => `  - ${ds.datasetUrl} (accessed ${ds.accessTimestamp})`)
+    .join('\n');
+
+  return `## Original Prompt
+${pkg.prompt.text || '[prompt text not available]'}
+
+## Tool Calls Made (${pkg.queries.length} total)
+${toolCallSummary || '  (none)'}
+
+## Data Sources
+${dataSources || '  (none)'}
+
+## Model Used
+${pkg.cost.model}
+
+## AI Output
+${pkg.output}`;
+}
+
+export type ParsedEvaluation =
+  | { ok: true; results: EvaluationResults }
+  | { ok: false; error: string; raw: string };
+
+/**
+ * Parse + validate an evaluator response into structured results. Pure —
+ * unit-tested directly. Strips markdown fences (some models wrap despite the
+ * instruction), requires every criterion with a numeric score, and recomputes
+ * the aggregate when the model omits it.
+ */
+export function parseEvaluationResponse(raw: string): ParsedEvaluation {
+  const jsonStr = raw.replace(/```json\s*/g, '').replace(/```\s*/g, '').trim();
+  let parsed: Record<string, { score?: unknown; comment?: unknown }> & {
+    overallScore?: unknown;
+    assessment?: unknown;
+  };
+  try {
+    parsed = JSON.parse(jsonStr);
+  } catch {
+    return { ok: false, error: 'Evaluator returned invalid JSON', raw };
+  }
+
+  const perCriterion: EvaluationResults['perCriterion'] = {};
+  for (const key of EVALUATION_CRITERIA) {
+    const entry = parsed[key];
+    if (!entry || typeof entry.score !== 'number') {
+      return { ok: false, error: `Missing or invalid rubric criterion: ${key}`, raw };
+    }
+    perCriterion[key] = {
+      score: entry.score,
+      comment: typeof entry.comment === 'string' ? entry.comment : '',
+    };
+  }
+
+  const overallScore =
+    typeof parsed.overallScore === 'number'
+      ? parsed.overallScore
+      : EVALUATION_CRITERIA.reduce((sum, k) => sum + perCriterion[k].score, 0) /
+        EVALUATION_CRITERIA.length;
+
+  return {
+    ok: true,
+    results: {
+      perCriterion,
+      overallScore,
+      assessment: typeof parsed.assessment === 'string' ? parsed.assessment : '',
+    },
+  };
+}

--- a/packages/civic-typed-harness/tsconfig.json
+++ b/packages/civic-typed-harness/tsconfig.json
@@ -1,0 +1,29 @@
+{
+  // Build config for civic-typed-harness. Mirrors @typedstandards/produce-core:
+  // the source is browser-safe and imports siblings with explicit `.ts`
+  // extensions. `rewriteRelativeImportExtensions` converts those to `.js` on
+  // emit so the built ESM resolves under plain Node, bundlers, and the browser
+  // alike — one source, no per-target rewrite.
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+
+    "declaration": true,
+    "declarationMap": false,
+    "sourceMap": false,
+    "outDir": "dist",
+    "rootDir": "src",
+
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true,
+    "rewriteRelativeImportExtensions": true,
+    "forceConsistentCasingInFileNames": true,
+    "noUncheckedIndexedAccess": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "dist", "node_modules"]
+}


### PR DESCRIPTION
Phase 1 of the S2 sprint (anchor #116): the domain layer of ADR-0021's format/domain line, relocated from the reference app as an installable package.

## What lands
- Root `package.json` gains `workspaces: ["packages/*"]` (stays private); `node_modules/` ignored — the repo's first npm dependency.
- **`packages/civic-typed-harness`** — runtime dep exactly `@typedstandards/produce-core@^0.1.0`. Three module groups with a mechanically enforced boundary: `format/` (vocabulary, civic source registry, datHere policy, profile re-exports), `capture/` (TraceBuilder on noble-hashes, skill-metadata extraction, data-source population with caller-supplied resolver, provenance builder on produce-core's PROV helpers), `rubric/` (adversarial-eval pure core). No capture module defines vocabulary; no format module walks a trace; README reserves the future split.
- **Config-not-constants:** platform agent, source registry, environment host, trace service identity are typed config inputs with the civicaitools values as exported demo defaults.
- **ADR-0022** (Proposed): workspaces + first package, working-name status, no-publish-this-sprint, the module-boundary hedge.

## Evidence (independently re-verified by the orchestrator)
- 89/89 workspace tests green; purity lint (restricted imports + browser-safety test) exits clean; negative-proof checked (violations in `format/` fire, sanctioned clock/RNG in `capture/` lints clean).
- `RUBRIC_VERSION_SHA256` byte-exact: `b62b193c…fa02` re-captured from the reference implementation by executing its module directly.
- Golden byte-parity fixtures regenerated from the reference implementation (never hand-edited); synthetic fixture values follow the guard-safe convention (timestamps under 13 digits, seeded ids in the hex-letter range).
- Blast zone held: root package.json/lockfile, `.gitignore` (one line), `packages/**`, `docs/adr/0022` — nothing else; reference-app and dependency repos untouched.
- The app is NOT re-pointed (that is S3). No npm publish this sprint (G0 decision 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)