### PR TITLE
skill: derive the publish blob host from server responses (S2 P3)

### DIFF
--- a/.claude/skills/publish-evidence/SKILL.md
+++ b/.claude/skills/publish-evidence/SKILL.md
@@ -205,7 +205,7 @@ The threshold can be overridden with `--max-inline-bytes N` (e.g., force-inline 
 
    The script resolves auth in this order and uses the first that matches: saved bearer token → `CIVICAITOOLS_SESSION_TOKEN` → `CIVICAITOOLS_SESSION_TOKEN_OP`. Never echo those values. Never pass them on the command line. Oversized fields are uploaded to Vercel Blob before the `/api/evidence` POST; each upload uses the same credentials as the main POST.
 
-4. On success the script prints a JSON result with `slug`, `evidenceUrl`, `packageHash`, and `readbackUrl`. Show the user:
+4. On success the script prints a JSON result with `slug`, `evidenceUrl`, `packageHash`, and `readbackUrl` — plus, for published (not committed) records, `blobHint`: the canonical, content-addressable package-blob URL. The blob host is not baked into the script; it is read from the target instance's own response (`packageUrl` on the public `GET /api/evidence/<slug>/commitment`), falling back to a blob URL returned by an upload earlier in the same run. If neither is available the hint is omitted with a warning; `--blob-host` (or `CIVICAITOOLS_BLOB_HOST`) is the escape hatch for instances whose commitment endpoint isn't reachable from where the skill runs. Show the user:
    - The full evidence URL (`https://civicaitools.org/evidence/<slug>`)
    - The package hash (first 12 chars is fine)
    - A one-line next-step hint: "Open the URL to run adversarial / consistency attestations from the dashboard."

--- a/.claude/skills/publish-evidence/publish.py
+++ b/.claude/skills/publish-evidence/publish.py
@@ -43,6 +43,11 @@ Environment variables (read at run time, never logged):
                                     resolved via ``op read``.
     CIVICAITOOLS_BASE_URL           Override the publish base URL
                                     (default ``https://www.civicaitools.org``).
+    CIVICAITOOLS_BLOB_HOST          Escape hatch only. Public blob-store
+                                    host used to build the package
+                                    ``blobHint``. Unset by default — the
+                                    host is read out of the server's own
+                                    responses (see ``resolve_blob_host``).
     XDG_CONFIG_HOME                 Respected when locating the
                                     credentials file.
 
@@ -66,6 +71,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 import uuid
 import webbrowser
@@ -1049,11 +1055,99 @@ def post_evidence(
         sys.exit(3)
 
 
-VERCEL_BLOB_HOST = "ayoozcuc1c16axbw.public.blob.vercel-storage.com"
+# --------------------------------------------------------------------------
+# Package blob URL — host derived from the server's own responses
+# --------------------------------------------------------------------------
+#
+# The public blob-store host is instance identity, not protocol: every
+# deployment of the registry has its own store. It is therefore never a
+# constant in this script (which adopters copy verbatim) — it is read back
+# out of URLs the target instance itself produced.
 
 
-def blob_url_for(package_hash: str) -> str:
-    return f"https://{VERCEL_BLOB_HOST}/evidence-packages/{package_hash}.json"
+def blob_host_from_url(url: Any) -> str | None:
+    """Return the host component of ``url``, or None if it isn't a usable
+    absolute HTTP(S) URL."""
+    if not isinstance(url, str) or not url.strip():
+        return None
+    try:
+        parsed = urllib.parse.urlsplit(url.strip())
+    except ValueError:
+        return None
+    if parsed.scheme not in ("https", "http") or not parsed.netloc:
+        return None
+    return parsed.netloc
+
+
+def blob_url_for(package_hash: str, blob_host: str) -> str:
+    """Canonical, content-addressable package-blob URL on ``blob_host``.
+
+    Mirrors the server's own key convention for published packages —
+    ``evidence-packages/<packageHash>.json``, no random suffix. The host
+    comes from ``resolve_blob_host``; there is no default.
+    """
+    return f"https://{blob_host}/evidence-packages/{package_hash}.json"
+
+
+def fetch_commitment_blob_host(base_url: str, slug: str) -> str | None:
+    """Read this instance's blob host off the public commitment view.
+
+    ``GET /api/evidence/<slug>/commitment`` needs no authentication and
+    carries ``packageUrl`` — the canonical, public package-blob URL for
+    the record just published. Best-effort: any failure returns None and
+    the caller degrades to omitting the hint rather than guessing a host.
+    """
+    url = f"{base_url.rstrip('/')}/api/evidence/{slug}/commitment"
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={"User-Agent": "civic-ai-tools-publish-evidence/0.3"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            parsed = json.loads(resp.read().decode("utf-8"))
+    except (OSError, ValueError):
+        # OSError covers urllib's URLError/HTTPError and socket timeouts;
+        # ValueError covers json.JSONDecodeError and decode failures.
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return blob_host_from_url(parsed.get("packageUrl"))
+
+
+def resolve_blob_host(
+    *,
+    override: str | None,
+    base_url: str,
+    slug: str,
+    observed_urls: list[str],
+) -> str | None:
+    """Resolve the target instance's public blob host.
+
+    Resolution order:
+
+    1. ``--blob-host`` / ``CIVICAITOOLS_BLOB_HOST`` — documented escape
+       hatch for environments where the commitment endpoint isn't
+       reachable from where the skill runs. Unset in the default flow.
+    2. The commitment view's ``packageUrl`` — server-authoritative for
+       the package blob on whichever instance was just published to.
+    3. A blob URL this run already received from the store while
+       uploading BlobRef fields (same store as the package blob). Used
+       only when (2) is unreachable, and costs no extra request.
+
+    Returns None when no response offered a host; the caller then omits
+    the hint instead of guessing.
+    """
+    if override and override.strip():
+        return blob_host_from_url(override) or override.strip().strip("/")
+    host = fetch_commitment_blob_host(base_url, slug)
+    if host:
+        return host
+    for url in observed_urls:
+        host = blob_host_from_url(url)
+        if host:
+            return host
+    return None
 
 
 def _redacted_preview(
@@ -1287,6 +1381,17 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--blob-host",
+        default=os.environ.get("CIVICAITOOLS_BLOB_HOST", ""),
+        help=(
+            "Escape hatch: the target instance's public blob-store host "
+            "(e.g. `<store>.public.blob.vercel-storage.com`), used to "
+            "build the `blobHint` in the result. Not needed in the normal "
+            "flow — the host is read from the server's own commitment "
+            "response. Defaults to $CIVICAITOOLS_BLOB_HOST."
+        ),
+    )
+    parser.add_argument(
         "--dev",
         action="store_true",
         help="Use the dev cookie name `next-auth.session-token` instead of "
@@ -1404,8 +1509,12 @@ def main() -> None:
     auth_method, auth_value = resolve_auth(args.base_url)
     cookie_name = DEV_COOKIE_NAME if args.dev else PROD_COOKIE_NAME
 
+    # Blob URLs the store returns during this run. Kept as a fallback
+    # source for the instance's blob host (see resolve_blob_host).
+    uploaded_blob_urls: list[str] = []
+
     def do_upload(value: Any, content_type: str, extension: str) -> dict[str, Any]:
-        return upload_blob_ref(
+        blob_ref = upload_blob_ref(
             value=value,
             content_type=content_type,
             extension=extension,
@@ -1414,6 +1523,9 @@ def main() -> None:
             auth_value=auth_value,
             cookie_name=cookie_name,
         )
+        if isinstance(blob_ref.get("url"), str):
+            uploaded_blob_urls.append(blob_ref["url"])
+        return blob_ref
 
     body, _stats = build_request_body(
         payload,
@@ -1458,7 +1570,23 @@ def main() -> None:
             "Publish from the civicaitools.org dashboard when ready."
         )
     else:
-        output["blobHint"] = blob_url_for(package_hash)
+        blob_host = resolve_blob_host(
+            override=args.blob_host,
+            base_url=args.base_url,
+            slug=slug,
+            observed_urls=uploaded_blob_urls,
+        )
+        if blob_host:
+            output["blobHint"] = blob_url_for(package_hash, blob_host)
+        else:
+            eprint(
+                "warning: could not resolve this instance's blob host from "
+                "the server's responses, so `blobHint` is omitted. The "
+                "canonical package URL is served as `packageUrl` by "
+                f"{args.base_url.rstrip('/')}/api/evidence/{slug}/commitment; "
+                "set CIVICAITOOLS_BLOB_HOST (or --blob-host) if that "
+                "endpoint isn't reachable from here."
+            )
 
     print(json.dumps(output, indent=2))
 

--- a/.claude/skills/publish-evidence/test_publish.py
+++ b/.claude/skills/publish-evidence/test_publish.py
@@ -1,16 +1,24 @@
-"""Minimal tests for publish.py — negative pattern scan + captureMethod
-validation. Run with ``python3 test_publish.py`` (no pytest dependency).
+"""Minimal tests for publish.py — negative pattern scan, captureMethod
+validation, and blob-host derivation. Run with ``python3 test_publish.py``
+(no pytest dependency).
 
 Per civic-ai-tools#60 / ADR-0003. The publishing model's full JSONL-readback
 pipeline is end-to-end-tested by actual publishes; these tests cover only
-the gates that publish.py itself enforces."""
+the gates that publish.py itself enforces. No test makes a live API call or
+needs a session token — every server response is stubbed."""
 from __future__ import annotations
 
 import io
+import json
+import os
+import re
 import sys
+import tempfile
 import unittest
-from contextlib import redirect_stderr
+import urllib.error
+from contextlib import redirect_stderr, redirect_stdout
 from pathlib import Path
+from unittest import mock
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import publish  # noqa: E402  (import after sys.path tweak)
@@ -61,6 +69,317 @@ class CaptureMethodValidationTests(unittest.TestCase):
         with self.assertRaises(SystemExit) as cm, redirect_stderr(io.StringIO()):
             publish.validate_payload(_payload(captureMethod="made-up"))
         self.assertEqual(cm.exception.code, 2)
+
+
+# --------------------------------------------------------------------------
+# Blob-host derivation (no instance-specific constant in the skill)
+# --------------------------------------------------------------------------
+
+# Stand-in hosts. Any value works — the point of the change is that the
+# script carries no host of its own.
+STORE_HOST = "examplestore0001.public.blob.vercel-storage.com"
+OTHER_HOST = "otherstore0002.public.blob.vercel-storage.com"
+PACKAGE_HASH = "deadbeef" * 8  # 64 hex chars, same shape as a real hash
+BASE_URL = "https://www.example.org"
+SLUG = "some-analysis-deadbe"
+
+
+def _legacy_blob_url_for(host: str, package_hash: str) -> str:
+    """The pre-change implementation, verbatim, with the module-level
+    host constant replaced by a parameter.
+
+    This is the byte-compatibility reference: whatever host the server
+    reports, the URL the script emits must equal what the old constant-
+    based code emitted for that same host.
+    """
+    return f"https://{host}/evidence-packages/{package_hash}.json"
+
+
+class _FakeResponse:
+    """Minimal stand-in for the object urlopen returns."""
+
+    def __init__(self, body: str, headers: dict[str, str] | None = None) -> None:
+        self._body = body.encode("utf-8")
+        self.headers = headers or {}
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+
+def _commitment_response(host: str, package_hash: str = PACKAGE_HASH) -> _FakeResponse:
+    """A stubbed `GET /api/evidence/<slug>/commitment` body, shaped like
+    the documented commitment view (only the fields we read matter)."""
+    return _FakeResponse(
+        json.dumps(
+            {
+                "evidenceProtocolVersion": "0.1.0",
+                "packageHash": package_hash,
+                "packageUrl": _legacy_blob_url_for(host, package_hash),
+                "captureMethod": "claude-code-jsonl-readback",
+            }
+        )
+    )
+
+
+class BlobUrlByteCompatTests(unittest.TestCase):
+    """`blob_url_for` must be byte-identical to the pre-change code."""
+
+    def test_url_matches_legacy_formula(self) -> None:
+        for host in (STORE_HOST, OTHER_HOST, "blob.example.gov"):
+            with self.subTest(host=host):
+                self.assertEqual(
+                    publish.blob_url_for(PACKAGE_HASH, host),
+                    _legacy_blob_url_for(host, PACKAGE_HASH),
+                )
+
+    def test_end_to_end_hint_matches_legacy_for_same_server_state(self) -> None:
+        """Resolution + construction together reproduce the old output.
+
+        Given a server whose package blobs live on ``STORE_HOST`` — the
+        situation the removed constant described — the emitted hint is
+        byte-identical to what the constant produced.
+        """
+        with mock.patch(
+            "urllib.request.urlopen", return_value=_commitment_response(STORE_HOST)
+        ):
+            host = publish.resolve_blob_host(
+                override="",
+                base_url=BASE_URL,
+                slug=SLUG,
+                observed_urls=[],
+            )
+        self.assertEqual(
+            publish.blob_url_for(PACKAGE_HASH, host),
+            _legacy_blob_url_for(STORE_HOST, PACKAGE_HASH),
+        )
+
+
+class NoInstanceConstantTests(unittest.TestCase):
+    def test_module_has_no_blob_host_constant(self) -> None:
+        self.assertFalse(hasattr(publish, "VERCEL_BLOB_HOST"))
+
+    def test_source_carries_no_concrete_store_host(self) -> None:
+        """A `<store>` placeholder in help text is fine; a real store id
+        is not."""
+        source = Path(publish.__file__).read_text(encoding="utf-8")
+        matches = re.findall(
+            r"[A-Za-z0-9]{6,}\.public\.blob\.vercel-storage\.com", source
+        )
+        self.assertEqual(matches, [])
+
+    def test_blob_url_for_requires_an_explicit_host(self) -> None:
+        with self.assertRaises(TypeError):
+            publish.blob_url_for(PACKAGE_HASH)  # type: ignore[call-arg]
+
+
+class BlobHostFromUrlTests(unittest.TestCase):
+    def test_extracts_host(self) -> None:
+        self.assertEqual(
+            publish.blob_host_from_url(_legacy_blob_url_for(STORE_HOST, PACKAGE_HASH)),
+            STORE_HOST,
+        )
+
+    def test_rejects_non_urls(self) -> None:
+        for value in (None, "", "   ", 42, {}, "not a url", "ftp://x/y"):
+            with self.subTest(value=value):
+                self.assertIsNone(publish.blob_host_from_url(value))
+
+
+class FetchCommitmentBlobHostTests(unittest.TestCase):
+    def test_reads_host_from_package_url(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen", return_value=_commitment_response(STORE_HOST)
+        ) as urlopen:
+            host = publish.fetch_commitment_blob_host(BASE_URL, SLUG)
+        self.assertEqual(host, STORE_HOST)
+        requested = urlopen.call_args.args[0]
+        self.assertEqual(
+            requested.full_url, f"{BASE_URL}/api/evidence/{SLUG}/commitment"
+        )
+        # Public endpoint — the fetch must carry no credentials.
+        header_names = {k.lower() for k in requested.headers}
+        self.assertNotIn("authorization", header_names)
+        self.assertNotIn("cookie", header_names)
+
+    def test_network_failure_returns_none(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=urllib.error.URLError("down")
+        ):
+            self.assertIsNone(publish.fetch_commitment_blob_host(BASE_URL, SLUG))
+
+    def test_unparseable_body_returns_none(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen", return_value=_FakeResponse("<html>nope</html>")
+        ):
+            self.assertIsNone(publish.fetch_commitment_blob_host(BASE_URL, SLUG))
+
+    def test_missing_package_url_returns_none(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen",
+            return_value=_FakeResponse(json.dumps({"packageHash": PACKAGE_HASH})),
+        ):
+            self.assertIsNone(publish.fetch_commitment_blob_host(BASE_URL, SLUG))
+
+
+class ResolveBlobHostTests(unittest.TestCase):
+    def test_commitment_response_is_the_default_source(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen", return_value=_commitment_response(STORE_HOST)
+        ):
+            host = publish.resolve_blob_host(
+                override="",
+                base_url=BASE_URL,
+                slug=SLUG,
+                observed_urls=[],
+            )
+        self.assertEqual(host, STORE_HOST)
+
+    def test_uploaded_blob_url_is_the_fallback(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=urllib.error.URLError("down")
+        ):
+            host = publish.resolve_blob_host(
+                override="",
+                base_url=BASE_URL,
+                slug=SLUG,
+                observed_urls=[
+                    f"https://{OTHER_HOST}/evidence-refs/{PACKAGE_HASH}.md"
+                ],
+            )
+        self.assertEqual(host, OTHER_HOST)
+
+    def test_override_wins_without_any_request(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=AssertionError("override must not hit the network"),
+        ):
+            self.assertEqual(
+                publish.resolve_blob_host(
+                    override=OTHER_HOST,
+                    base_url=BASE_URL,
+                    slug=SLUG,
+                    observed_urls=[f"https://{STORE_HOST}/evidence-refs/x.md"],
+                ),
+                OTHER_HOST,
+            )
+
+    def test_override_accepts_a_full_url(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen",
+            side_effect=AssertionError("override must not hit the network"),
+        ):
+            self.assertEqual(
+                publish.resolve_blob_host(
+                    override=f"https://{OTHER_HOST}/",
+                    base_url=BASE_URL,
+                    slug=SLUG,
+                    observed_urls=[],
+                ),
+                OTHER_HOST,
+            )
+
+    def test_no_source_returns_none(self) -> None:
+        with mock.patch(
+            "urllib.request.urlopen", side_effect=urllib.error.URLError("down")
+        ):
+            self.assertIsNone(
+                publish.resolve_blob_host(
+                    override=None,
+                    base_url=BASE_URL,
+                    slug=SLUG,
+                    observed_urls=[],
+                )
+            )
+
+
+class PublishOutputTests(unittest.TestCase):
+    """End-to-end over the one call path that produces a blob URL:
+    ``main()`` publishing a package. All server responses are stubbed —
+    no network, no credentials."""
+
+    def _run_main(self, commitment: object) -> tuple[dict[str, object], str]:
+        """Run ``main()`` against a stubbed server. ``commitment`` is the
+        stubbed response (or exception) for the commitment GET. Returns
+        ``(parsed_stdout, stderr_text)``."""
+        publish_response = _FakeResponse(
+            json.dumps(
+                {
+                    "slug": SLUG,
+                    "url": f"/evidence/{SLUG}",
+                    "packageHash": PACKAGE_HASH,
+                    "visibility": "published",
+                }
+            )
+        )
+
+        def fake_urlopen(req: object, *args: object, **kwargs: object) -> object:
+            full_url = getattr(req, "full_url", "")
+            if full_url.endswith("/commitment"):
+                if isinstance(commitment, Exception):
+                    raise commitment
+                return commitment
+            if full_url.endswith("/api/evidence"):
+                return publish_response
+            raise AssertionError(f"unexpected request to {full_url}")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            payload_path = Path(tmp) / "payload.json"
+            payload_path.write_text(
+                json.dumps(
+                    _payload(
+                        toolCalls=[
+                            {
+                                "name": "get_data",
+                                "source": "socrata",
+                                "args": {"type": "query"},
+                            }
+                        ]
+                    )
+                ),
+                encoding="utf-8",
+            )
+            argv = [
+                "publish.py",
+                "--payload",
+                str(payload_path),
+                "--base-url",
+                BASE_URL,
+            ]
+            stdout, stderr = io.StringIO(), io.StringIO()
+            with mock.patch.object(sys, "argv", argv), mock.patch.object(
+                publish, "resolve_auth", return_value=("bearer", "stub-token")
+            ), mock.patch("urllib.request.urlopen", side_effect=fake_urlopen), \
+                    redirect_stdout(stdout), redirect_stderr(stderr):
+                publish.main()
+        return json.loads(stdout.getvalue()), stderr.getvalue()
+
+    def test_hint_is_derived_from_the_commitment_response(self) -> None:
+        result, stderr = self._run_main(_commitment_response(STORE_HOST))
+        self.assertEqual(
+            result["blobHint"], _legacy_blob_url_for(STORE_HOST, PACKAGE_HASH)
+        )
+        self.assertEqual(stderr, "")
+
+    def test_hint_omitted_when_no_response_offers_a_host(self) -> None:
+        result, stderr = self._run_main(urllib.error.URLError("down"))
+        self.assertNotIn("blobHint", result)
+        self.assertIn("blob host", stderr)
+        # The rest of the result is unaffected.
+        self.assertEqual(result["slug"], SLUG)
+        self.assertEqual(result["packageHash"], PACKAGE_HASH)
+
+    def test_hint_honours_the_escape_hatch(self) -> None:
+        with mock.patch.dict(os.environ, {"CIVICAITOOLS_BLOB_HOST": OTHER_HOST}):
+            result, _stderr = self._run_main(_commitment_response(STORE_HOST))
+        self.assertEqual(
+            result["blobHint"], _legacy_blob_url_for(OTHER_HOST, PACKAGE_HASH)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Phase 3 of the S2 sprint (anchor #116): no instance-specific constant in a skill any adopter copies.

## What lands
- `VERCEL_BLOB_HOST` is gone. `blob_url_for()` now requires an explicit host, resolved per publish by `resolve_blob_host()`: (1) `--blob-host`/`CIVICAITOOLS_BLOB_HOST` escape hatch (unset by default), (2) **`packageUrl` from the public `GET /api/evidence/<slug>/commitment`** — server-authoritative for whichever instance was published to, (3) a blob URL the store already returned during this run's uploads, (4) omit the `blobHint` with a stderr warning rather than guess. `VERCEL_BLOB_API_URL` (wire protocol, not identity) stays.
- Rationale for the commitment endpoint: the `POST /api/evidence` response deliberately does not return the blob URL, and upload-token responses only exist for oversized fields — the commitment view is the one server response available on every published call path with zero configuration.
- `test_publish.py`: 23 → 26 tests (15 new). Byte-compat is proven against the pre-change implementation carried verbatim in the test file — including an end-to-end `main()` run with stubbed server responses asserting the printed `blobHint` is byte-identical to the legacy output. No test touches the network or needs a token; the commitment GET is asserted to carry no auth headers.
- One behavioral delta, by design: the default published flow now performs one extra public, unauthenticated GET per publish to derive the host. Output bytes are unchanged.

## Evidence (independently re-verified by the orchestrator)
26/26 tests on a fresh run; demo-host string absent from all tracked files (locked in by tests two ways); blast zone exactly three files under `.claude/skills/publish-evidence/`; guard-safe convention held per-commit; workspace tests (113/113) unaffected; reference-app and dependency repos untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)