### PR TITLE
docs: ADR-0022 → Accepted (status flip)

### DIFF
--- a/docs/adr/0022-civic-typed-harness-packaging.md
+++ b/docs/adr/0022-civic-typed-harness-packaging.md
@@ -1,7 +1,7 @@
 # ADR-0022: Civic-harness packaging — npm workspaces and the first package in the hub repo
 
-- **Status:** Proposed
-- **Date:** 2026-08-01 (drafted by the S2 P1 implementation session, riding its PR per the sprint's G0 decision 1)
+- **Status:** **Accepted** 2026-08-01 (maintainer review, post-merge of #117)
+- **Date:** 2026-08-01 (decision; drafted the same day by the S2 P1 implementation session, riding its PR per the sprint's G0 decision 1)
 - **Decision-maker:** Solo maintainer
 - **Supersedes:** —
 - **Superseded by:** —


### PR DESCRIPTION
One-hunk follow-up to #117: flips ADR-0022 (civic-typed-harness packaging — workspaces + the hub repo's first package) to **Accepted 2026-08-01** after maintainer review. Same pattern as #114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)