### PR TITLE
docs: ADR-0023 → Accepted (status flip)

### DIFF
--- a/docs/adr/0023-notebook-executor-driver.md
+++ b/docs/adr/0023-notebook-executor-driver.md
@@ -1,6 +1,6 @@
 # ADR-0023: Notebook executor as a driver interface — Vercel Sandbox default, local container-runner as the portable shape
 
-- **Status:** **Proposed** 2026-08-04 (drafted by the S3b P4 implementation session, riding its PR; acceptance is a maintainer-review flip, per the ADR-0022 precedent)
+- **Status:** **Accepted** 2026-08-05 (maintainer review, post-merge of #125; the seam shipped in civic-ai-tools-website#176 and its both-drivers parity bar was met byte-identically)
 - **Date:** 2026-08-04 (decision + draft)
 - **Decision-maker:** Solo maintainer
 - **Supersedes:** —


### PR DESCRIPTION
One-hunk status flip after maintainer review, following the ADR-0022/#120 precedent.

ADR-0023 (notebook executor as a driver interface) was merged as **Proposed** riding the S3b P4 implementation PR. The maintainer has now reviewed it. Supporting evidence for acceptance:

- The seam shipped in [civic-ai-tools-website#176](https://github.com/npstorey/civic-ai-tools-website/pull/176) exactly as the ADR describes: `NotebookExecutorDriver` with lazy driver loading, the hosted-sandbox driver relocated verbatim as the default, and the local container-runner as driver #2.
- The both-drivers parity bar was met **byte-identically** (`sha256 df3187bd…` on both drivers' normalized results).
- The compose acceptance exercised the container driver end to end on ordinary infrastructure (4.2s execution, single-sourced pinned stack surfaced in the evidence envelope).
- Decision E's anti-drift mechanism is live: the Dockerfile mirror is test-enforced rather than comment-guarded.

No content changes — status line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)