### PR TITLE
Light housekeeping pass: front-door routing, status labels, doc indexes (#134)

### DIFF
--- a/.github/ISSUE_TEMPLATE/roadmap-change.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-change.md
@@ -41,7 +41,7 @@ Does this change create, remove, or modify any of the nine commitments in Sectio
 
 ## Linked issues and context
 
-Issue numbers across the three repos, prior discussions, ADRs.
+Issue numbers across the four repos, prior discussions, ADRs.
 
 ## Acknowledgement
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Civic AI Tools sits at one layer of a broader landscape where open data meets AI
 
 > **Integrating against the evidence registry?** The reference implementation and its integration contract live in [civic-ai-tools-website](https://github.com/npstorey/civic-ai-tools-website) — start at [`docs/api/evidence-publish.md`](https://github.com/npstorey/civic-ai-tools-website/blob/main/docs/api/evidence-publish.md). This repo holds the protocol decisions (ADRs, the open-questions registry) and the Typed Standards Specification the contract cites.
 
+> **Reviewing the standard?** The Typed Standards Specification is [`docs/architecture/typed-standards-specification.md`](docs/architecture/typed-standards-specification.md) (v0.1 Working Draft, CC BY 4.0); the short version is [`typed-standards-summary.md`](docs/architecture/typed-standards-summary.md). Reviewers should start at [`docs/community-review/v0.1-rfc-reviewer-orientation.md`](docs/community-review/v0.1-rfc-reviewer-orientation.md) — a one-page reading guide.
+
+> **Running your own instance?** This repo is the local starter. To deploy the evidence platform on your own infrastructure, see [`civic-ai-tools-website/docs/deploy.md`](https://github.com/npstorey/civic-ai-tools-website/blob/main/docs/deploy.md).
+
 ## What can you do with this?
 
 - Ask questions about NYC 311 complaints, restaurant inspections, or housing violations in plain English
@@ -82,10 +86,17 @@ See [examples/README.md](examples/README.md) for the full list.
 
 ## Related projects
 
+Civic AI Tools is one of four repositories in this project — see [CONTRIBUTING.md](CONTRIBUTING.md#this-is-a-multi-repo-project) for the full map and where to file what.
+
 | Repository | Description |
 |-----------|-------------|
 | [socrata-mcp-server](https://github.com/npstorey/socrata-mcp-server) | The MCP server that connects AI tools to Socrata open data portals. This repo uses it as a dependency. |
 | [civic-ai-tools-website](https://github.com/npstorey/civic-ai-tools-website) | Demo website at [civicaitools.org](https://civicaitools.org) — side-by-side comparison of AI with and without live data access |
+| [typedstandards](https://github.com/npstorey/typedstandards) | The standard's home — @typedstandards/verify-core, @typedstandards/produce-core, and [typedstandards.org](https://typedstandards.org). The specification *text* lives in this repo; the packages and site live there. |
+
+## Packages
+
+This repo is an npm workspace. [packages/civic-typed-harness](packages/civic-typed-harness) publishes as [`@typedstandards/civic-typed-harness`](https://www.npmjs.com/package/@typedstandards/civic-typed-harness) — the civic **domain** harness layered on `@typedstandards/produce-core`'s neutral envelope assembly ([ADR-0021](docs/adr/0021-produce-core-extraction.md), [ADR-0022](docs/adr/0022-civic-typed-harness-packaging.md)).
 
 ## Documentation
 
@@ -107,9 +118,11 @@ See [examples/README.md](examples/README.md) for the full list.
 
 ### Architecture
 - [docs/architecture/](docs/architecture/) — Canonical architecture documents and spec drafts (internal working drafts; not stable specs)
+- [docs/architecture/typed-standards-specification.md](docs/architecture/typed-standards-specification.md) — **the Typed Standards Specification** (v0.1 Working Draft, CC BY 4.0). Version-tagged: changes are patch revisions, not edits.
+- [docs/community-review/](docs/community-review/) — reviewer orientation and the circulated render of the spec.
 - [docs/architecture/end-state-vision.md](docs/architecture/end-state-vision.md) — Layered architecture target with build-state coloring and full glossary
-- [docs/architecture/open-evidence-standard.md](docs/architecture/open-evidence-standard.md) — Internal working draft of the Open Evidence Standard (pre-v0.1)
-- [docs/architecture/civic-claim-vocabulary-draft-spec.md](docs/architecture/civic-claim-vocabulary-draft-spec.md) — Internal working draft of the Civic Claim Vocabulary, the typed-claims layer (pre-v0.1)
+- [docs/architecture/open-evidence-standard.md](docs/architecture/open-evidence-standard.md) — **Historical snapshot, frozen 2026-05-26**; envelope-layer content consolidated into the Typed Standards Specification (ADR-0012)
+- [docs/architecture/civic-claim-vocabulary-draft-spec.md](docs/architecture/civic-claim-vocabulary-draft-spec.md) — **Historical snapshot, frozen 2026-05-26**; typed-claims-layer content consolidated into the specification (ADR-0012)
 - [docs/architecture/xanadu-doctrine.md](docs/architecture/xanadu-doctrine.md) — Project discipline gating spec growth
 - **[docs/architecture/open-questions.md](docs/architecture/open-questions.md)** — Open questions registry. Canonical home for unresolved decisions affecting the architecture and standards. Start here when deciding what's settled vs. what's still in flight.
 
@@ -122,6 +135,8 @@ See [examples/README.md](examples/README.md) for the full list.
 ## Contributing
 
 Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines — there are ways to help even if you don't write code.
+
+Two CI gates run on every PR and are worth knowing before you start: **skill-drift** (docs/skills/{base,local,web}.md are byte-compared against the copies embedded in socrata-mcp-server — regenerate with `node scripts/check-skill-drift.mjs --emit <dir>`, never hand-transcribe) and **dependency budgets** (`npm run check:budgets`).
 
 ## Glossary
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -125,7 +125,7 @@ Scope-request categories the project explicitly does not take on. Each has a sho
 
 - **Platform-issued correctness claims.** The registry publishes *disclosures*, not *validations*. Expert attestations, when present, are separately signed objects produced by identifiable attesters.
 
-- **Enterprise SLAs or managed hosting.** The demo runs on standard Vercel Pro. All three repos are open source; organizations wanting higher SLAs should run their own instances.
+- **Enterprise SLAs or managed hosting.** The demo runs on standard Vercel Pro. All four repos are open source; organizations wanting higher SLAs should run their own instances.
 
 - **Editorial moderation of published analyses at scale.** Withdrawal and reinstatement are signed, public actions available to authors. The registry does not editorially moderate beyond obvious-abuse response. Hosting an evidence package does not endorse its claims.
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,29 @@
+# Architectural Decision Records
+
+Numbered, immutable records of settled project decisions — each documents one decision, its context, and its consequences; later ADRs supersede or refine earlier ones by reference rather than by editing them.
+
+| ADR | Title | Status |
+|-----|-------|--------|
+| [0001](0001-roadmap-governance.md) | Public-roadmap governance | Accepted |
+| [0002](0002-commitments-vs-targets.md) | Trust commitments vs. operational targets | Accepted |
+| [0003](0003-evidence-capture-method.md) | Capture-method differentiation for evidence packages | Accepted |
+| [0004](0004-dathere-captureMethod-variant.md) | `datHere` content profile — A-G envelope, deterministic notebook, cross-host commitment view | Accepted |
+| [0005](0005-executed-notebook-architecture.md) | Executed-notebook architecture for the `datHere` content profile | Proposed |
+| [0006](0006-producer-profile-architecture.md) | Producer Profile architecture — subtypes / flavors and the production-process attestation reframe | Proposed |
+| [0007](0007-content-canonicalization.md) | `contentCanonicalization` — sixth envelope field naming the off-log content canonicalization rule | Proposed |
+| [0008](0008-multihash-content-hash.md) | Multihash `contentHash` + RFC 8785 JCS envelope canonicalization | Proposed |
+| [0009](0009-unified-typed-attestation-primitive.md) | Unified typed-attestation primitive — one structural envelope, two top-level type families | Proposed |
+| [0010](0010-visibility-lifecycle-location-attestations.md) | Visibility, lifecycle, and location as attestations | Proposed |
+| [0011](0011-capturemethod-generalization.md) | captureMethod generalization — open enum at core, per-profile vocabulary | Proposed |
+| [0012](0012-typed-standards-consolidation.md) | Consolidate OES + CCV under the Typed Standards umbrella — `ts:` namespace, `typed-publisher.json` well-known path, CC BY 4.0 spec license | Proposed |
+| [0013](0013-verification-rendering-delegation.md) | Verification rendering — glance in-page, full detail delegated to a neutral client-side verifier | Accepted |
+| [0014](0014-evidence-system-fork-resolution-path-b.md) | Resolve the evidence-system fork toward Path B (domain-neutral), realized spec-first via Typed Standards | Accepted |
+| [0015](0015-adversarial-eval-publication-gate.md) | Adversarial-evaluation publication gate — host policy + default-on, presence-based | Proposed (implementation shipped; flips to Accepted on review) |
+| [0016](0016-vcs-native-lifecycle-mapping.md) | Mapping the lifecycle/visibility model onto a VCS-native evidence-notebook workflow | Accepted (2026-06-15) |
+| [0017](0017-ipr-posture-dco-rf-statement.md) | IPR posture — DCO inbound + maintainer royalty-free patent statement, as a pre-RFC gate | Accepted (2026-07-07) |
+| 0018 | Number skipped; no record exists (gap noted 2026-08-09). | — |
+| [0019](0019-reference-app-posture.md) | Reference-application product posture — open-source, demo-hostable, fork-first ("Postgres, not Heroku") | Accepted (2026-07-31) |
+| [0020](0020-instance-key-custody.md) | Key custody for instances (Q56) — per-instance keys with an intentional unsigned dev tier | Accepted (2026-07-31) |
+| [0021](0021-produce-core-extraction.md) | Producer-side core extraction (`@typedstandards/produce-core`) and the format/domain line (Q59) | Accepted (2026-07-31) |
+| [0022](0022-civic-typed-harness-packaging.md) | Civic-harness packaging — npm workspaces and the first package in the hub repo | Accepted (2026-08-01) |
+| [0023](0023-notebook-executor-driver.md) | Notebook executor as a driver interface — Vercel Sandbox default, local container-runner as the portable shape | Accepted (2026-08-05) |

--- a/docs/architecture/typed-standards-summary.md
+++ b/docs/architecture/typed-standards-summary.md
@@ -6,6 +6,8 @@ Companion: typed-standards-specification.md (full version)
 License: CC BY 4.0 (same as the full specification)
 ---
 
+> **Companion, not authority.** This is the leave-behind summary of the Typed Standards Specification. It was last updated 2026-05-26; the specification has moved since. Where the two differ, [typed-standards-specification.md](typed-standards-specification.md) governs.
+
 # Typed Standards
 
 An open standard for **production-process attestation** of analytical artifacts: a cryptographically signed, content-addressed, capture-method-labeled record of *how* an artifact was produced, verifiable by a third party who does not trust the publisher.

--- a/docs/datasets.md
+++ b/docs/datasets.md
@@ -5,6 +5,8 @@ High-value civic datasets across major Socrata open data portals. This is a hand
 Last verified: 2026-03-08
 License: CC0 1.0 — this directory (the curation, descriptions, and field notes) is dedicated to the public domain; see [LICENSING.md](../LICENSING.md). The datasets it points to are governed by their source portals' terms.
 
+> **Point-in-time curation.** Dataset IDs and availability were last verified on the date above. Portals retire and re-key datasets; if an ID here 404s, use the MCP server's search tool and please [open an issue](https://github.com/npstorey/civic-ai-tools/issues).
+
 ---
 
 ## NYC Open Data (`data.cityofnewyork.us`)

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -1,0 +1,8 @@
+# Proposals
+
+Scoping documents for candidate work. A proposal is not a commitment — each carries its own status line.
+
+- [data-concierge-integration.md](data-concierge-integration.md) — Status: Proposal (last updated 2026-05-16). Integration arc between the evidence-package system and an external publisher's notebook-based publishing tool (Pittsburgh / WPRDC pilot).
+- [dpg-readiness.md](dpg-readiness.md) — Status: Proposal (last updated 2026-05-16). Documentation readiness plan for submission to the Digital Public Goods Alliance registry.
+
+Dispositions are tracked in GitHub issues and the [open-questions registry](../architecture/open-questions.md), not by editing these files.

--- a/docs/research/README.md
+++ b/docs/research/README.md
@@ -1,0 +1,16 @@
+# Research artifacts
+
+Point-in-time research documents. Each file carries its own status line; none of these is a decision — decisions land in [`../adr/`](../adr/) and the [open-questions registry](../architecture/open-questions.md).
+
+- [agent-receipts-evaluation.md](agent-receipts-evaluation.md) — Evaluation of the Agent Receipts protocol against the evidence system's OTel trace layer (last updated April 2026).
+- [betanyc-mcp-integration-evaluation.md](betanyc-mcp-integration-evaluation.md) — Evaluation of BetaNYC's six MCP servers as candidate data sources; research, not a decision — no integration scoped or committed (last updated July 2026).
+- [census-mcp-evaluation.md](census-mcp-evaluation.md) — Candidate MCP servers for US demographic data (Data Commons vs. a dedicated Census MCP), for the M9 milestone (last updated April 2026).
+- [census-mcp-landscape.md](census-mcp-landscape.md) — Narrower companion to the landscape analysis, scoped to census and federal statistical tooling in AI-assisted analysis (last updated April 2026).
+- [civic-analytics-skill-comparison.md](civic-analytics-skill-comparison.md) — Comparison of an external civic-analytics Claude Skill set against this project's skill guidance; research, not a decision.
+- [dataset-directory-evaluation.md](dataset-directory-evaluation.md) — Evaluation of the curated dataset directory's size (2026-03-10); retained as method-of-record, not a live decision.
+- [eval-queries.md](eval-queries.md) — Test queries and scoring rubric behind the model evaluation (2026-03-10); retained as method-of-record, not a live decision.
+- [landscape-analysis.md](landscape-analysis.md) — Map of projects and organizations at the AI + civic data intersection (last updated 2026-04-24).
+- [model-evaluation-results.md](model-evaluation-results.md) — Point-in-time snapshot of the 2026-03-10 model evaluation run; read for methodology and failure taxonomy, not for a current ranking.
+- [odp-mcp-analysis.md](odp-mcp-analysis.md) — Pagination and result-limit patterns in socrata/odp-mcp; research, not a decision (March 2026).
+- [skill-routing-architectural-shapes.md](skill-routing-architectural-shapes.md) — Design space for dynamic skill-guidance routing across multiple MCP sources; research, not a decision (April 2026).
+- [theory-of-change/](theory-of-change/) — AI-assisted theory-of-change research folder; citations machine-checked, synthesis not yet vetted by a human (see its README).

--- a/docs/research/dataset-directory-evaluation.md
+++ b/docs/research/dataset-directory-evaluation.md
@@ -1,5 +1,7 @@
 # Dataset Directory Size Evaluation
 
+*Research artifact from 2026-03-10. Retained as method-of-record; not a live decision.*
+
 Analysis of whether the current curated dataset directory (~15-20 datasets per portal, 78 total) is optimal for AI-assisted civic data queries.
 
 Created: 2026-03-10

--- a/docs/research/eval-queries.md
+++ b/docs/research/eval-queries.md
@@ -1,5 +1,7 @@
 # Model Evaluation: Test Queries & Scoring Rubric
 
+*Research artifact from 2026-03-10. Retained as method-of-record; not a live decision.*
+
 Framework for systematically evaluating LLM performance on civic data queries via the Socrata MCP server.
 
 Created: 2026-03-10

--- a/docs/research/model-evaluation-results.md
+++ b/docs/research/model-evaluation-results.md
@@ -1,5 +1,7 @@
 # Model Evaluation Results
 
+> **Point-in-time snapshot — evaluation run 2026-03-10, not repeated.** Model lineups, pricing, and tool-calling reliability have all moved since. Read this for the *methodology* ([eval-queries.md](eval-queries.md)) and the failure taxonomy, not for a current ranking.
+
 Systematic comparison of LLM performance on civic data queries via the Socrata MCP server.
 
 Evaluation date: 2026-03-10

--- a/docs/research/odp-mcp-analysis.md
+++ b/docs/research/odp-mcp-analysis.md
@@ -1,5 +1,7 @@
 # odp-mcp Analysis: Pagination and Result Limit Patterns
 
+*Research, not a decision. Captured March 2026; no follow-up work committed.*
+
 Research for [civic-ai-tools#18](https://github.com/npstorey/civic-ai-tools/issues/18). Analyzed [socrata/odp-mcp](https://github.com/socrata/odp-mcp) (commit history as of March 2026).
 
 ## Result Size Limits

--- a/docs/research/skill-routing-architectural-shapes.md
+++ b/docs/research/skill-routing-architectural-shapes.md
@@ -1,6 +1,6 @@
 # Skill routing architectural shapes
 
-*Research, not a decision. Captures the design space for dynamic skill-guidance loading when a project wires up multiple MCP data sources.*
+*Research, not a decision. Captures the design space for dynamic skill-guidance loading when a project wires up multiple MCP data sources. Captured April 2026; no follow-up work committed.*
 
 ## Context
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,4 +1,11 @@
+---
+Status: Reference guide — last verified 2026-03-08
+Audience: Anyone setting up the local starter (VS Code, Cursor, Claude Code, Codex)
+---
+
 # Setup Guide
+
+> The short path is the [README quick start](../README.md#quick-start). This guide is the long form: prerequisites, per-tool setup, API keys, and troubleshooting.
 
 This guide walks you through setting up the civic-ai-tools project to work with **Cursor IDE** or **Claude Code CLI**.
 

--- a/docs/skills/README.md
+++ b/docs/skills/README.md
@@ -10,6 +10,7 @@ This directory contains the companion skill guidance for the MCP servers the civ
 | `web.md` | Socrata web overlay: aggressive date defaults, demo limits, token-conscious formatting, no cross-portal comparisons, local tools CTA |
 | `local.md` | Socrata local overlay: relaxed date defaults, full capabilities, cross-portal comparisons encouraged, extended analysis OK |
 | `data-commons.md` | Google Data Commons skill: two-tool workflow, DCID patterns, small-area coverage, aggregation-semantics risks, cross-source decision logic, attribution |
+| `boston.md` | Boston OpenContext skill: CKAN-vs-Socrata cheat sheet, Boston geographies (neighborhoods ≠ Census tracts, BPD districts, parcel IDs), resource-UUID citation. No embedded server copy — not drift-checked. |
 
 ## How overlays work
 
@@ -37,5 +38,6 @@ Clients can also explicitly request a modality by passing `modality: "web"` or `
 To add support for a new modality (e.g., Slack, mobile):
 
 1. Create a new overlay file (e.g., `slack.md`) in this directory.
-2. Add the corresponding skill file in `socrata-mcp-server/src/skills/`.
-3. Update the `GetPrompt` handler in the MCP server to compose with the new overlay.
+2. Add its name to `EMBEDDED_SKILLS` in `scripts/check-skill-drift.mjs`, so the new embedded copy is covered by the drift check.
+3. Render the embedded module with `node scripts/check-skill-drift.mjs --emit <dir>` and land the emitted file in `socrata-mcp-server/src/skills/` — do not transcribe by hand (see Governance above).
+4. Update the `GetPrompt` handler in the MCP server to compose with the new overlay.

--- a/docs/sustainability.md
+++ b/docs/sustainability.md
@@ -5,7 +5,7 @@
 
 ## Current state
 
-civic-ai-tools is a solo-maintained, self-funded, open-source project. All three repositories are MIT-licensed. The demo website runs on Vercel Pro; the Socrata MCP server runs on Render's paid tier; storage is Neon Postgres plus Vercel Blob. Costs are personal; maintainer time is uncompensated.
+civic-ai-tools is a solo-maintained, self-funded, open-source project. All four repositories are MIT-licensed. The demo website runs on Vercel Pro; the Socrata MCP server runs on Render's paid tier; storage is Neon Postgres plus Vercel Blob. Costs are personal; maintainer time is uncompensated.
 
 Release cadence has held at one-to-two-week coordinated cross-repo tags since v0.1.0 (March 2026). The evidence system shipped at v0.6.0, multi-source data access shipped at v0.7.0 and v0.8.0. `ROADMAP.md` is refreshed quarterly.
 
@@ -30,7 +30,7 @@ Without adopting commitments that would require a team, funding could accelerate
 
 ## What funding would not change
 
-- The MIT license on all three repositories.
+- The MIT license on all four repositories.
 - The *disclosure, not validation* stance in the evidence system.
 - The public, issue-linked roadmap and the ADR process.
 - The out-of-scope list in `ROADMAP.md` Section 7 — including no proprietary data sources, no platform-issued correctness claims, no enterprise SLAs, and no editorial moderation at scale.

--- a/examples/REAL_DATA_ANALYSIS.md
+++ b/examples/REAL_DATA_ANALYSIS.md
@@ -1,5 +1,7 @@
 # Real Data Analysis Results 🎯
 
+> **Historical output — generated January 2026, not re-run since.** Kept as a worked example of the analysis shape, not as current data. The scripts that produced it are in this directory and can be re-run; the numbers below are a snapshot and should not be cited. (The "January 2025" line below is a typo in the original output — the file entered the repo in January 2026.)
+
 **Generated:** January 2025  
 **Data Sources:** NYC Open Data (Socrata API) & Google Data Commons
 


### PR DESCRIPTION
Docs-only housekeeping pass per the approved edit list on #134 (rows 1–13 + the new-file and surgical approvals), **plus row 14 and the governance-steps correction per the owner ruling delivered mid-task** — those two land as the separate second commit so they can be dropped at review if desired.

## Front-door routing (README.md)

- Two routing blockquotes after the existing evidence-registry one: **Reviewing the standard?** (spec + summary + reviewer orientation; verified v0.1 Working Draft / CC BY 4.0 against the spec's front matter) and **Running your own instance?** (link to the website repo's `docs/deploy.md`).
- Related projects: lead-in sentence ("one of four repositories", linked to CONTRIBUTING.md's multi-repo section anchor) + a typedstandards row.
- New **Packages** section: the npm workspace and `@typedstandards/civic-typed-harness` on `@typedstandards/produce-core` (ADR-0021/0022 linked; relationship verified against the package's own package.json and README).
- Architecture doc list: added the spec bullet and a `docs/community-review/` bullet; **replaced the two false "Internal working draft … (pre-v0.1)" bullets** for open-evidence-standard.md and civic-claim-vocabulary-draft-spec.md with accurate "Historical snapshot, frozen 2026-05-26 … consolidated per ADR-0012" ones (attribution verified against both files' front matter).
- Contributing: one paragraph naming the two CI gates (skill-drift byte-compare + `--emit <dir>` regeneration; `npm run check:budgets`), commands verified against package.json and `.github/workflows/ci.yml`.

## Surgical "three repos" → four

`ROADMAP.md` (out-of-scope §), `docs/sustainability.md` (×2 — all four repos verified MIT-licensed before asserting), `.github/ISSUE_TEMPLATE/roadmap-change.md`.

## Status headers

Point-in-time / historical labels added to: `examples/REAL_DATA_ANALYSIS.md` (**date corrected to January 2026** — the survey draft's "January 2025" copies a typo in the file's own Generated line; git shows the file entered the repo 2026-01-08; the header notes the typo), `docs/setup.md` (front matter + short-path pointer to the README quick start; anchor verified), `docs/datasets.md`, `docs/research/model-evaluation-results.md`, `eval-queries.md`, `dataset-directory-evaluation.md`, `skill-routing-architectural-shapes.md` (April 2026 from git history; existing "Research, not a decision" line extended rather than duplicated), `odp-mcp-analysis.md` (March 2026 from git history), `docs/architecture/typed-standards-summary.md` ("Companion, not authority").

## New thin indexes

- `docs/adr/README.md` — number · title · status table from each ADR's own title/status lines; ADR-0018 listed as "number skipped; no record exists (gap noted 2026-08-09)".
- `docs/research/README.md` — one line per artifact; method-of-record vs point-in-time only where the file itself says so.
- `docs/proposals/README.md` — the two proposals with their stated status; dispositions tracked in issues + the open-questions registry.

## Row 14 + governance-steps correction per owner ruling (second commit, droppable)

- `docs/skills/README.md` Files table: `boston.md` row — every clause verified against boston.md's actual content (CKAN-vs-Socrata table, neighborhoods ≠ Census tracts / BPD districts / parcel IDs, resource-UUID citation; `EMBEDDED_SKILLS = ['base','local','web']` confirms no embedded copy / not drift-checked).
- `docs/skills/README.md` §Adding a new modality: the steps were **flatly wrong**, not merely ambiguous — a new Socrata modality overlay necessarily becomes an embedded copy in socrata-mcp-server (the GetPrompt handler composes from embedded constants), so step 2's "add the corresponding skill file" instructed exactly the hand-transcription the Governance section forbids, and the steps omitted drift-check registration. Rewritten minimally to the real flow derived from `scripts/check-skill-drift.mjs`: create overlay → register in `EMBEDDED_SKILLS` → `--emit <dir>` and land the emitted module → update GetPrompt. (The "new source with no embedded copy" case — boston, data-commons — is a different *server*, not a Socrata modality, so it doesn't pass through these steps.)

Untouched by charter: `docs/skills/{base,local,web}.md` (CI byte-checked — both gates run locally and pass: skill-drift in-sync ×3 against the local sibling repo, dependency budgets OK), `docs/architecture/typed-standards-specification.md`, `docs/mcp-servers.md`. No files moved, renamed, or deleted.

Closes nothing on its own; tracked by #134.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
