### PR TITLE
chore: refresh the MCP server directory survey (#137)

### DIFF
--- a/data/mcp-servers.json
+++ b/data/mcp-servers.json
@@ -67,33 +67,6 @@
     ]
   },
   {
-    "id": "odp-mcp",
-    "name": "odp-mcp",
-    "description": "Socrata open data portals",
-    "repoUrl": "https://github.com/socrata/odp-mcp",
-    "transport": [
-      "stdio"
-    ],
-    "categories": [
-      "open-data-portals"
-    ],
-    "governmentLevel": [
-      "multi"
-    ],
-    "maintainer": "Socrata (Tyler Technologies)",
-    "status": "active",
-    "dateAdded": "2026-03-14",
-    "dataSources": [
-      "Socrata open data portals"
-    ],
-    "verificationStatus": "community",
-    "dateModified": "2026-03-14",
-    "notes": "Official Socrata MCP server. Lightweight, read-only tools.",
-    "dataPlatform": [
-      "socrata"
-    ]
-  },
-  {
     "id": "socrata-mcp",
     "name": "Socrata-MCP",
     "description": "Socrata open data portals",
@@ -135,15 +108,15 @@
       "multi"
     ],
     "maintainer": "srobbin",
-    "status": "active",
+    "status": "inactive",
     "dateAdded": "2026-03-14",
     "dataSources": [
       "Socrata open data portals"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "apiKeyRequired": false,
-    "notes": "No API key required. ~10 stars, available via npx. Built by co-founder of Chi Hack Night.",
+    "notes": "No API key required. Available via npx. Built by co-founder of Chi Hack Night. No repository commits since 2025-04-09 (verified 2026-08-12).",
     "dataPlatform": [
       "socrata"
     ]
@@ -331,10 +304,11 @@
   {
     "id": "us-gov-open-data-mcp",
     "name": "us-gov-open-data-mcp",
-    "description": "36+ federal APIs (Census, EPA, NOAA, FDA, SEC, BLS, FRED, FEC, FBI, USDA, CDC, etc.)",
+    "description": "40+ federal APIs (Census, EPA, NOAA, FDA, SEC, BLS, FRED, FEC, FBI, USDA, CDC, etc.)",
     "repoUrl": "https://github.com/lzinga/us-gov-open-data-mcp",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "federal-government"
@@ -346,12 +320,12 @@
     "status": "active",
     "dateAdded": "2026-03-14",
     "dataSources": [
-      "36+ federal APIs (Census, EPA, NOAA, FDA, SEC, BLS, FRED, FEC, FBI, USDA, CDC, etc.)"
+      "40+ federal APIs (Census, EPA, NOAA, FDA, SEC, BLS, FRED, FEC, FBI, USDA, CDC, etc.)"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
-    "toolCount": 188,
-    "notes": "188+ tools. TypeScript SDK, caching, retry logic, selective module loading. 18 APIs need no key. Featured on Hacker News.",
+    "dateModified": "2026-08-12",
+    "toolCount": 300,
+    "notes": "300+ tools. TypeScript SDK, caching, retry logic, selective module loading. 20+ APIs need no key. Featured on Hacker News.",
     "priority": "tier1",
     "jurisdiction": "United States",
     "dataPlatform": [
@@ -432,14 +406,14 @@
       "federal"
     ],
     "maintainer": "melaodoidao",
-    "status": "active",
+    "status": "inactive",
     "dateAdded": "2026-03-14",
     "dataSources": [
       "Data.gov"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
-    "notes": "Search packages, view datasets, list groups/tags from the federal open data portal.",
+    "dateModified": "2026-08-12",
+    "notes": "Search packages, view datasets, list groups/tags from the federal open data portal. No repository commits since 2025-04-09 (verified 2026-08-12).",
     "jurisdiction": "United States",
     "dataPlatform": [
       "ckan"
@@ -479,7 +453,8 @@
     "description": "SAM.gov + USAspending.gov + Tango",
     "repoUrl": "https://github.com/blencorp/capture-mcp-server",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "federal-government"
@@ -494,7 +469,7 @@
       "SAM.gov + USAspending.gov + Tango"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "toolCount": 15,
     "notes": "15 tools for government contracting. Returns both human-readable text and structured JSON.",
     "jurisdiction": "United States",
@@ -508,7 +483,8 @@
     "description": "Congress.gov (bills, votes, members, committees)",
     "repoUrl": "https://github.com/amurshak/congressMCP",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "legislation-legal"
@@ -524,7 +500,7 @@
       "Congress.gov (bills, votes, members, committees)"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "6 tool suites, 113 functions. Free tier: 500 calls/month; Pro: $19/month. GitHub.",
     "jurisdiction": "United States",
     "dataPlatform": [
@@ -535,7 +511,7 @@
     "id": "congress-gov-mcp",
     "name": "congress-gov-mcp",
     "description": "Congress.gov API v3",
-    "repoUrl": "https://github.com/ashwinsundar/congress_gov_mcp",
+    "repoUrl": "https://github.com/AshwinSundar/congress_gov_mcp",
     "transport": [
       "stdio"
     ],
@@ -547,14 +523,14 @@
       "state"
     ],
     "maintainer": "AshwinSundar",
-    "status": "active",
+    "status": "inactive",
     "dateAdded": "2026-03-14",
     "dataSources": [
       "Congress.gov API v3"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
-    "notes": "Bills, amendments, voting records, committee info, member details.",
+    "dateModified": "2026-08-12",
+    "notes": "Bills, amendments, voting records, committee info, member details. No repository commits since 2025-06-30 (verified 2026-08-12).",
     "jurisdiction": "United States",
     "dataPlatform": [
       "custom-api"
@@ -626,7 +602,8 @@
     "description": "CourtListener (3,352 U.S. courts)",
     "repoUrl": "https://github.com/blakeox/courtlistener-mcp",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "legislation-legal"
@@ -642,7 +619,7 @@
       "CourtListener (3,352 U.S. courts)"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "toolCount": 20,
     "notes": "20+ tools. Opinions, dockets, judges, oral arguments, financial disclosures.",
     "jurisdiction": "United States",
@@ -654,7 +631,7 @@
     "id": "umbrella-terminal-mcp",
     "name": "umbrella-terminal-mcp",
     "description": "Colorado legislative intelligence",
-    "repoUrl": "https://glama.ai/mcp/servers/@TheBlackCompany/umbrella_terminal_mcp",
+    "repoUrl": "https://github.com/TheBlackCompany/umbrella_terminal_mcp",
     "transport": [
       "stdio"
     ],
@@ -672,7 +649,7 @@
       "Colorado legislative intelligence"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "toolCount": 67,
     "notes": "67 tools. Bills, statutes, rules, campaign finance. State-specific.",
     "jurisdiction": "United States",
@@ -883,7 +860,8 @@
     "description": "FRED (Federal Reserve Economic Data)",
     "repoUrl": "https://github.com/stefanoamorelli/fred-mcp-server",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "economic-financial"
@@ -898,7 +876,7 @@
       "FRED (Federal Reserve Economic Data)"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "800,000+ economic data series. Categories, releases, sources.",
     "priority": "tier2",
     "jurisdiction": "United States",
@@ -912,7 +890,8 @@
     "description": "SEC EDGAR (13M+ filings)",
     "repoUrl": "https://github.com/stefanoamorelli/sec-edgar-mcp",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "economic-financial"
@@ -927,7 +906,7 @@
       "SEC EDGAR (13M+ filings)"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "XBRL financials, company info. Docker image available.",
     "jurisdiction": "United States",
     "dataPlatform": [
@@ -1140,7 +1119,7 @@
     "id": "riksdag-regering-mcp",
     "name": "riksdag-regering-mcp",
     "description": "Swedish Parliament + Government",
-    "repoUrl": "https://github.com/isakskogstad/riksdag-regering-mcp",
+    "repoUrl": "https://github.com/isakskogstad/Riksdag-Regering-MCP",
     "transport": [
       "stdio"
     ],
@@ -1157,7 +1136,7 @@
       "Swedish Parliament + Government"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "Open data from Swedish legislative and executive branches.",
     "jurisdiction": "Sweden",
     "dataPlatform": [
@@ -1225,8 +1204,8 @@
   {
     "id": "swedish-law-mcp",
     "name": "swedish-law-mcp",
-    "description": "Swedish, Danish, Finnish law",
-    "repoUrl": "https://github.com/Ansvar-Systems/swedish-law-mcp",
+    "description": "Swedish statutes and regulations",
+    "repoUrl": "https://github.com/Ansvar-Systems/Swedish-law-mcp",
     "transport": [
       "stdio"
     ],
@@ -1237,14 +1216,14 @@
       "international"
     ],
     "maintainer": "Ansvar-Systems",
-    "status": "active",
+    "status": "archived",
     "dateAdded": "2026-03-14",
     "dataSources": [
-      "Swedish, Danish, Finnish law"
+      "Swedish statutes and regulations"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
-    "notes": "Also Danish and Finnish law MCPs from the same maintainer.",
+    "dateModified": "2026-08-12",
+    "notes": "Archived by the maintainer (verified 2026-08-12); last commit 2026-07-07. The maintainer's Danish- and Finnish-law MCP servers are archived as well.",
     "jurisdiction": "Sweden",
     "dataPlatform": [
       "custom-api"
@@ -1256,7 +1235,8 @@
     "description": "e-Stat (Japan statistics)",
     "repoUrl": "https://github.com/ajtgjmdjp/estat-mcp",
     "transport": [
-      "stdio"
+      "stdio",
+      "sse"
     ],
     "categories": [
       "international-government"
@@ -1271,7 +1251,7 @@
       "e-Stat (Japan statistics)"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "3,000+ tables: population, economy, prices, labor, agriculture.",
     "jurisdiction": "Japan",
     "dataPlatform": [
@@ -1341,7 +1321,8 @@
     "description": "Malaysia data.gov.my",
     "repoUrl": "https://github.com/hithereiamaliff/mcp-datagovmy",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "international-government"
@@ -1356,7 +1337,7 @@
       "Malaysia data.gov.my"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "Includes GTFS transit data tools.",
     "jurisdiction": "Malaysia",
     "dataPlatform": [
@@ -1378,14 +1359,14 @@
       "international"
     ],
     "maintainer": "keonho-kim",
-    "status": "active",
+    "status": "inactive",
     "dateAdded": "2026-03-14",
     "dataSources": [
       "South Korea DART (corporate disclosures)"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
-    "notes": "Korean financial disclosures via OpenDart API.",
+    "dateModified": "2026-08-12",
+    "notes": "Korean financial disclosures via OpenDart API. No repository commits since 2025-06-22 (verified 2026-08-12).",
     "jurisdiction": "South Korea",
     "dataPlatform": [
       "custom-api"
@@ -1395,9 +1376,10 @@
     "id": "budgetkey-mcp",
     "name": "budgetkey-mcp",
     "description": "Israel budget transparency",
-    "repoUrl": "https://github.com/openbudget/budgetkey-mcp",
+    "repoUrl": "https://github.com/OpenBudget/budgetkey-mcp",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "international-government"
@@ -1405,14 +1387,14 @@
     "governmentLevel": [
       "international"
     ],
-    "maintainer": "openbudget",
+    "maintainer": "OpenBudget",
     "status": "active",
     "dateAdded": "2026-03-14",
     "dataSources": [
       "Israel budget transparency"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "Israeli budget transparency data.",
     "jurisdiction": "Israel",
     "dataPlatform": [
@@ -1423,7 +1405,7 @@
     "id": "gov-ca-mcp",
     "name": "gov-ca-mcp",
     "description": "Government of Canada (250,000+ datasets)",
-    "repoUrl": "https://glama.ai/mcp/servers/@krunal16-c/gov-ca-mcp",
+    "repoUrl": "https://github.com/krunal16-c/gov-ca-mcp",
     "transport": [
       "stdio"
     ],
@@ -1440,7 +1422,7 @@
       "Government of Canada (250,000+ datasets)"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "Two servers: datasets and transportation (bridges, airports, cycling, transit, railways).",
     "jurisdiction": "Canada",
     "dataPlatform": [
@@ -1480,7 +1462,7 @@
     "id": "bcb-mcp",
     "name": "bcb-mcp",
     "description": "Brazil Central Bank",
-    "repoUrl": "https://lobehub.com/mcp/sidneybissoli-bcb-br-mcp",
+    "repoUrl": "https://github.com/SidneyBissoli/bcb-br-mcp",
     "transport": [
       "stdio"
     ],
@@ -1497,7 +1479,7 @@
       "Brazil Central Bank"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "Selic, IPCA, exchange rates, GDP time series.",
     "jurisdiction": "Brazil",
     "dataPlatform": [
@@ -1507,7 +1489,7 @@
   {
     "id": "agrobr-mcp",
     "name": "agrobr-mcp",
-    "description": "Brazilian agriculture (19 sources)",
+    "description": "Brazilian agriculture (10 sources)",
     "repoUrl": "https://github.com/bruno-portfolio/agrobr-mcp",
     "transport": [
       "stdio"
@@ -1522,10 +1504,10 @@
     "status": "active",
     "dateAdded": "2026-03-14",
     "dataSources": [
-      "Brazilian agriculture (19 sources)"
+      "Brazilian agriculture (10 sources)"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "CEPEA, CONAB, IBGE, INPE, B3. Prices, crop estimates, climate, deforestation.",
     "jurisdiction": "Brazil",
     "dataPlatform": [
@@ -1536,7 +1518,7 @@
     "id": "world-bank-data-mcp",
     "name": "world-bank-data-mcp",
     "description": "World Bank Data360",
-    "repoUrl": "https://github.com/llnormll/world-bank-data-mcp",
+    "repoUrl": "https://github.com/llnOrmll/world-bank-data-mcp",
     "transport": [
       "stdio"
     ],
@@ -1546,14 +1528,14 @@
     "governmentLevel": [
       "global"
     ],
-    "maintainer": "llnormll",
+    "maintainer": "llnOrmll",
     "status": "active",
     "dateAdded": "2026-03-14",
     "dataSources": [
       "World Bank Data360"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "1,000+ indicators, 200+ countries. WDI, HNP, GDF, IDS datasets.",
     "jurisdiction": "Global",
     "dataPlatform": [
@@ -1575,14 +1557,14 @@
       "multi"
     ],
     "maintainer": "OpenDataMCP",
-    "status": "active",
+    "status": "inactive",
     "dateAdded": "2026-03-14",
     "dataSources": [
       "Universal open data portals"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
-    "notes": "Universal framework aiming to connect any open data portal to any LLM via MCP. Starting with Switzerland.",
+    "dateModified": "2026-08-12",
+    "notes": "Universal framework aiming to connect any open data portal to any LLM via MCP. Starting with Switzerland. No repository commits since 2024-12-20 (verified 2026-08-12).",
     "dataPlatform": [
       "ckan"
     ]
@@ -1593,7 +1575,8 @@
     "description": "Any CKAN portal worldwide",
     "repoUrl": "https://github.com/ondata/ckan-mcp-server",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "framework-multi-portal",
@@ -1609,7 +1592,7 @@
       "Any CKAN portal worldwide"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "Generic CKAN connector. Works with data.gov, data.gov.uk, data.europa.eu, and hundreds more. Docs.",
     "priority": "tier1",
     "dataPlatform": [
@@ -1679,7 +1662,8 @@
     "description": "GIS operations",
     "repoUrl": "https://github.com/mahdin75/gis-mcp",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "geospatial-gis"
@@ -1694,7 +1678,7 @@
       "GIS operations"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "Shapely, PyProj, GeoPandas, Rasterio, PySAL. Geometry, coordinate transforms, spatial analysis.",
     "dataPlatform": [
       "custom-api"
@@ -1762,7 +1746,8 @@
     "description": "Open-Meteo (weather, climate)",
     "repoUrl": "https://github.com/cmer81/open-meteo-mcp",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "weather-environment"
@@ -1777,7 +1762,7 @@
       "Open-Meteo (weather, climate)"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "apiKeyRequired": false,
     "notes": "7-day forecasts, ERA5 historical data from 1940, air quality, marine, CMIP6 climate projections. No API key.",
     "dataPlatform": [
@@ -1790,7 +1775,8 @@
     "description": "20+ NASA APIs",
     "repoUrl": "https://github.com/ProgramComputer/NASA-MCP-server",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "civic-adjacent"
@@ -1805,7 +1791,7 @@
       "20+ NASA APIs"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "APOD, Mars Rover, EPIC earth imagery, NEO, EONET, DONKI, GIBS, POWER, JPL.",
     "dataPlatform": [
       "custom-api"
@@ -1817,7 +1803,8 @@
     "description": "USPTO Patents",
     "repoUrl": "https://github.com/riemannzeta/patent_mcp_server",
     "transport": [
-      "stdio"
+      "stdio",
+      "http"
     ],
     "categories": [
       "civic-adjacent"
@@ -1832,7 +1819,7 @@
       "USPTO Patents"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "Patent Public Search, PTAB, PatentsView, Office Action, Patent Litigation.",
     "dataPlatform": [
       "custom-api"
@@ -1842,7 +1829,7 @@
     "id": "mcp-nutrition-tools",
     "name": "mcp-nutrition-tools",
     "description": "USDA FoodData Central",
-    "repoUrl": "https://mcpservers.org/servers/zen-apps/mcp-nutrition-tools",
+    "repoUrl": "https://github.com/zen-apps/mcp-nutrition-tools",
     "transport": [
       "stdio"
     ],
@@ -1859,7 +1846,7 @@
       "USDA FoodData Central"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
+    "dateModified": "2026-08-12",
     "notes": "600,000+ foods. CC0 public domain.",
     "dataPlatform": [
       "custom-api"
@@ -1923,7 +1910,7 @@
     "id": "civicnet-mcp-server",
     "name": "civicnet-mcp-server",
     "description": "Federated civic infrastructure",
-    "repoUrl": "https://github.com/Publik-Works/civicnet-mcp-server",
+    "repoUrl": "https://github.com/CivikNet/civicnet-mcp-server",
     "transport": [
       "stdio"
     ],
@@ -1933,15 +1920,15 @@
     "governmentLevel": [
       "multi"
     ],
-    "maintainer": "Publik-Works",
-    "status": "active",
+    "maintainer": "CivikNet",
+    "status": "inactive",
     "dateAdded": "2026-03-14",
     "dataSources": [
       "Federated civic infrastructure"
     ],
     "verificationStatus": "community",
-    "dateModified": "2026-03-14",
-    "notes": "Federated civic infrastructure with equity principles.",
+    "dateModified": "2026-08-12",
+    "notes": "Federated civic infrastructure with equity principles. No repository commits since 2025-06-04 (verified 2026-08-12).",
     "dataPlatform": [
       "custom-api"
     ]

--- a/docs/mcp-servers.md
+++ b/docs/mcp-servers.md
@@ -4,7 +4,9 @@
 
 A directory of MCP servers for accessing civic and public data. Servers marked **Included** are pre-configured in this repo's setup.
 
-*Last surveyed: March 2026. Sources: GitHub, official MCP Registry, Glama, PulseMCP, mcpservers.org, mcp.so, Smithery, LobeHub, Playbooks.*
+*Last surveyed: August 2026 (2026-08-12). Sources: GitHub, official MCP Registry, Glama, PulseMCP, mcpservers.org, mcp.so, Smithery, LobeHub, Playbooks.*
+
+**This is a point-in-time survey, not a live status feed.** Every entry below states what was true on 2026-08-12; projects are archived, renamed, and revived between surveys. Check the linked repository before relying on an entry, and open an issue if you find one that has drifted.
 
 ## Included in civic-ai-tools
 
@@ -17,9 +19,8 @@ A directory of MCP servers for accessing civic and public data. Servers marked *
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [odp-mcp](https://github.com/socrata/odp-mcp) | Socrata open data portals | stdio | Socrata (Tyler Technologies) | Active | Official Socrata MCP server. Lightweight, read-only tools. |
 | [Socrata-MCP](https://github.com/Thomas-TyTech/Socrata-MCP) | Socrata open data portals | stdio | [@Thomas-TyTech](https://github.com/Thomas-TyTech) | Active | From a Tyler Technologies developer. Natural language queries generate insights. |
-| [opengov-mcp-server](https://github.com/srobbin/opengov-mcp-server) | Socrata open data portals | stdio | [@srobbin](https://github.com/srobbin) | Active | No API key required. ~10 stars, available via npx. Built by co-founder of Chi Hack Night. |
+| [opengov-mcp-server](https://github.com/srobbin/opengov-mcp-server) | Socrata open data portals | stdio | [@srobbin](https://github.com/srobbin) | Inactive | No API key required. Available via npx. Built by co-founder of Chi Hack Night. No repository commits since 2025-04-09 (verified 2026-08-12). |
 | [open-data-mcp](https://github.com/leomerida15/open-data-mcp) | Socrata open data portals | stdio | [@leomerida15](https://github.com/leomerida15) | Active | Socrata-based open data MCP. |
 | [nyc-mcp](https://lobehub.com/pl/mcp/forest-builds-nyc-mcp) | NYC Open Data (2,000+ datasets) | stdio | [@forest-builds](https://github.com/forest-builds) | Active | NYC-specific. City services, housing, transportation, events, spending. |
 | [boston-core-mcp](https://github.com/thealphacubicle/boston-core-mcp) | Analyze Boston (data.boston.gov) — 311 requests, crime, permits, transit, budget, housing, and more | http | City of Boston DoIT | Active | Official. V1 prototype; superseded by OpenContext (see opencontext entry) — the same author's v2 generalized framework. Deployed on AWS Lambda with CI/CD. 5 tools: search datasets, list all datasets, get dataset info, query data, get schema. Listed on mcpmarket.com/server/boston-core. |
@@ -39,23 +40,23 @@ A directory of MCP servers for accessing civic and public data. Servers marked *
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [us-gov-open-data-mcp](https://github.com/lzinga/us-gov-open-data-mcp) | 36+ federal APIs (Census, EPA, NOAA, FDA, SEC, BLS, FRED, FEC, FBI, USDA, CDC, etc.) | stdio | [@lzinga](https://github.com/lzinga) | Active | 188+ tools. TypeScript SDK, caching, retry logic, selective module loading. 18 APIs need no key. Featured on Hacker News. |
+| [us-gov-open-data-mcp](https://github.com/lzinga/us-gov-open-data-mcp) | 40+ federal APIs (Census, EPA, NOAA, FDA, SEC, BLS, FRED, FEC, FBI, USDA, CDC, etc.) | stdio, http | [@lzinga](https://github.com/lzinga) | Active | 300+ tools. TypeScript SDK, caching, retry logic, selective module loading. 20+ APIs need no key. Featured on Hacker News. |
 | [gov-mcp-servers](https://github.com/martc03/gov-mcp-servers) | 13 government data sources | stdio, http | [@martc03](https://github.com/martc03) | Active | Unified gateway packaging 13 production servers. Listed on official MCP Registry. |
 | [mcp-civic-data](https://github.com/EricGrill/mcp-civic-data) | 7 federal APIs (NOAA, Census, NASA, World Bank, Data.gov, EU) | stdio | [@EricGrill](https://github.com/EricGrill) | Active | 22 tools. No API keys required for most. Good starter server. |
-| [datagov-mcp-server](https://github.com/melaodoidao/datagov-mcp-server) | Data.gov | stdio | [@melaodoidao](https://github.com/melaodoidao) | Active | Search packages, view datasets, list groups/tags from the federal open data portal. |
+| [datagov-mcp-server](https://github.com/melaodoidao/datagov-mcp-server) | Data.gov | stdio | [@melaodoidao](https://github.com/melaodoidao) | Inactive | Search packages, view datasets, list groups/tags from the federal open data portal. No repository commits since 2025-04-09 (verified 2026-08-12). |
 | [usaspending-mcp-server](https://github.com/thsmale/usaspending-mcp-server) | USAspending.gov | http | [@thsmale](https://github.com/thsmale) | Active | Federal spending data. Streamable HTTP transport. |
-| [capture-mcp-server](https://github.com/blencorp/capture-mcp-server) | SAM.gov + USAspending.gov + Tango | stdio | [@blencorp](https://github.com/blencorp) | Active | 15 tools for government contracting. Returns both human-readable text and structured JSON. |
+| [capture-mcp-server](https://github.com/blencorp/capture-mcp-server) | SAM.gov + USAspending.gov + Tango | stdio, http | [@blencorp](https://github.com/blencorp) | Active | 15 tools for government contracting. Returns both human-readable text and structured JSON. |
 
 ## U.S. Legislative & Legal Servers
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [CongressMCP](https://github.com/amurshak/congressMCP) | Congress.gov (bills, votes, members, committees) | stdio | Lawgiver.ai | Active | 6 tool suites, 113 functions. Free tier: 500 calls/month; Pro: $19/month. GitHub. |
-| [congress-gov-mcp](https://github.com/ashwinsundar/congress_gov_mcp) | Congress.gov API v3 | stdio | [@AshwinSundar](https://github.com/AshwinSundar) | Active | Bills, amendments, voting records, committee info, member details. |
+| [CongressMCP](https://github.com/amurshak/congressMCP) | Congress.gov (bills, votes, members, committees) | stdio, http | Lawgiver.ai | Active | 6 tool suites, 113 functions. Free tier: 500 calls/month; Pro: $19/month. GitHub. |
+| [congress-gov-mcp](https://github.com/AshwinSundar/congress_gov_mcp) | Congress.gov API v3 | stdio | [@AshwinSundar](https://github.com/AshwinSundar) | Inactive | Bills, amendments, voting records, committee info, member details. No repository commits since 2025-06-30 (verified 2026-08-12). |
 | [legiscan-mcp](https://github.com/sh-patterson/legiscan-mcp) | LegiScan (all 50 states + Congress) | stdio | [@sh-patterson](https://github.com/sh-patterson) | Active | Search bills, get full text, track votes, look up legislators. Requires API key. |
 | [us-legal-mcp](https://github.com/JamesANZ/us-legal-mcp) | Congress + Federal Register + CourtListener | stdio | [@JamesANZ](https://github.com/JamesANZ) | Active | Multi-source aggregation for legal research. |
-| [courtlistener-mcp](https://github.com/blakeox/courtlistener-mcp) | CourtListener (3,352 U.S. courts) | stdio | [@blakeox](https://github.com/blakeox) | Active | 20+ tools. Opinions, dockets, judges, oral arguments, financial disclosures. |
-| [umbrella-terminal-mcp](https://glama.ai/mcp/servers/@TheBlackCompany/umbrella_terminal_mcp) | Colorado legislative intelligence | stdio | [@TheBlackCompany](https://github.com/TheBlackCompany) | Active | 67 tools. Bills, statutes, rules, campaign finance. State-specific. |
+| [courtlistener-mcp](https://github.com/blakeox/courtlistener-mcp) | CourtListener (3,352 U.S. courts) | stdio, http | [@blakeox](https://github.com/blakeox) | Active | 20+ tools. Opinions, dockets, judges, oral arguments, financial disclosures. |
+| [umbrella-terminal-mcp](https://github.com/TheBlackCompany/umbrella_terminal_mcp) | Colorado legislative intelligence | stdio | [@TheBlackCompany](https://github.com/TheBlackCompany) | Active | 67 tools. Bills, statutes, rules, campaign finance. State-specific. |
 | [nyc-council-mcp](https://github.com/BetaNYC/nyc-council-mcp) | NYC Council Legistar API | stdio | [@BetaNYC](https://github.com/BetaNYC) | Active | Launched 2026-05-21 by BetaNYC. Requires a free LEGISTAR_TOKEN per user. Credits @jehiah / intro.nyc as predecessor work on the Legistar API. Published on npm as @betanyc/nyc-council-mcp. |
 | [nyc-charter-laws-rules](https://github.com/BetaNYC/nyc-charter-laws-rules) | NYC Charter, NYC Administrative Code, Rules of the City of New York | stdio | [@BetaNYC](https://github.com/BetaNYC) | Active | Launched 2026-05-21 by BetaNYC. No API key required — JSON index bundled in the npm package (22,050 sections). Features a three-layer legal-disclaimer pattern (tool descriptions + response footer + get_version instruction) so responses cannot be returned without grounding caveats. Published on npm as @betanyc/nyc-charter-laws-rules. |
 
@@ -85,8 +86,8 @@ A directory of MCP servers for accessing civic and public data. Servers marked *
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [fred-mcp-server](https://github.com/stefanoamorelli/fred-mcp-server) | FRED (Federal Reserve Economic Data) | stdio | [@stefanoamorelli](https://github.com/stefanoamorelli) | Active | 800,000+ economic data series. Categories, releases, sources. |
-| [sec-edgar-mcp](https://github.com/stefanoamorelli/sec-edgar-mcp) | SEC EDGAR (13M+ filings) | stdio | [@stefanoamorelli](https://github.com/stefanoamorelli) | Active | XBRL financials, company info. Docker image available. |
+| [fred-mcp-server](https://github.com/stefanoamorelli/fred-mcp-server) | FRED (Federal Reserve Economic Data) | stdio, http | [@stefanoamorelli](https://github.com/stefanoamorelli) | Active | 800,000+ economic data series. Categories, releases, sources. |
+| [sec-edgar-mcp](https://github.com/stefanoamorelli/sec-edgar-mcp) | SEC EDGAR (13M+ filings) | stdio, http | [@stefanoamorelli](https://github.com/stefanoamorelli) | Active | XBRL financials, company info. Docker image available. |
 
 ## U.S. Government Contracting (Commercial)
 
@@ -111,53 +112,53 @@ A directory of MCP servers for accessing civic and public data. Servers marked *
 | [eurostat-mcp](https://github.com/ano-kuhanathan/eurostat-mcp) | Eurostat (37 European countries) | stdio | [@ano-kuhanathan](https://github.com/ano-kuhanathan) | Active | GDP, unemployment, inflation, population, trade. No API key required. |
 | [datos-gob-es-mcp](https://github.com/AlbertoUAH/datos-gob-es-mcp) | Spain (BOE + INE + AEMET + Datos.gob.es) | stdio | [@AlbertoUAH](https://github.com/AlbertoUAH) | Active | 11 tools, 5 resources, 6 prompts. Unified 4 Spanish data sources + 40,000+ datasets. |
 | [kolada-mcp](https://github.com/isakskogstad/Kolada-MCP) | Kolada (Sweden municipal statistics) | stdio | [@isakskogstad](https://github.com/isakskogstad) | Active | 5,000+ KPIs across 290 Swedish municipalities and 21 regions. |
-| [riksdag-regering-mcp](https://github.com/isakskogstad/riksdag-regering-mcp) | Swedish Parliament + Government | stdio | [@isakskogstad](https://github.com/isakskogstad) | Active | Open data from Swedish legislative and executive branches. |
+| [riksdag-regering-mcp](https://github.com/isakskogstad/Riksdag-Regering-MCP) | Swedish Parliament + Government | stdio | [@isakskogstad](https://github.com/isakskogstad) | Active | Open data from Swedish legislative and executive branches. |
 | [parliament-mcp](https://github.com/i-dot-ai/parliament-mcp) | UK Parliament | stdio | [@i-dot-ai](https://github.com/i-dot-ai) | Active | 13 tools including semantic search via Qdrant. |
 | [GovUK-MCP](https://stealthlabs.ai/govuk-mcp) | UK government data | stdio | Stealth Labs | Active | 24 tools + 15 visual widgets for UK government data. |
-| [swedish-law-mcp](https://github.com/Ansvar-Systems/swedish-law-mcp) | Swedish, Danish, Finnish law | stdio | [@Ansvar-Systems](https://github.com/Ansvar-Systems) | Active | Also Danish and Finnish law MCPs from the same maintainer. |
+| [swedish-law-mcp](https://github.com/Ansvar-Systems/Swedish-law-mcp) | Swedish statutes and regulations | stdio | [@Ansvar-Systems](https://github.com/Ansvar-Systems) | Archived | Archived by the maintainer (verified 2026-08-12); last commit 2026-07-07. The maintainer's Danish- and Finnish-law MCP servers are archived as well. |
 
 ### Asia-Pacific
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) | e-Stat (Japan statistics) | stdio | [@ajtgjmdjp](https://github.com/ajtgjmdjp) | Active | 3,000+ tables: population, economy, prices, labor, agriculture. |
+| [estat-mcp](https://github.com/ajtgjmdjp/estat-mcp) | e-Stat (Japan statistics) | stdio, sse | [@ajtgjmdjp](https://github.com/ajtgjmdjp) | Active | 3,000+ tables: population, economy, prices, labor, agriculture. |
 | [jpn-laws-mcp](https://github.com/michimani/jpn-laws-mcp-server) | Japanese laws (e-Gov) | stdio | [@michimani](https://github.com/michimani) | Active | No API key required. |
 | [data-gov-hk-mcp](https://www.pulsemcp.com/servers/tonychan-data-gov-hk) | DATA.GOV.HK (Hong Kong) | stdio | [@tonychan](https://github.com/tonychan) | Active | Official Hong Kong open data portal. Search datasets, browse categories. |
-| [mcp-datagovmy](https://github.com/hithereiamaliff/mcp-datagovmy) | Malaysia data.gov.my | stdio | [@hithereiamaliff](https://github.com/hithereiamaliff) | Active | Includes GTFS transit data tools. |
-| [OpenDart-mcp](https://github.com/keonho-kim/OpenDart-mcp) | South Korea DART (corporate disclosures) | stdio | [@keonho-kim](https://github.com/keonho-kim) | Active | Korean financial disclosures via OpenDart API. |
+| [mcp-datagovmy](https://github.com/hithereiamaliff/mcp-datagovmy) | Malaysia data.gov.my | stdio, http | [@hithereiamaliff](https://github.com/hithereiamaliff) | Active | Includes GTFS transit data tools. |
+| [OpenDart-mcp](https://github.com/keonho-kim/OpenDart-mcp) | South Korea DART (corporate disclosures) | stdio | [@keonho-kim](https://github.com/keonho-kim) | Inactive | Korean financial disclosures via OpenDart API. No repository commits since 2025-06-22 (verified 2026-08-12). |
 
 ### Middle East
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [budgetkey-mcp](https://github.com/openbudget/budgetkey-mcp) | Israel budget transparency | stdio | [@openbudget](https://github.com/openbudget) | Active | Israeli budget transparency data. |
+| [budgetkey-mcp](https://github.com/OpenBudget/budgetkey-mcp) | Israel budget transparency | stdio, http | [@OpenBudget](https://github.com/OpenBudget) | Active | Israeli budget transparency data. |
 
 ### Americas
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [gov-ca-mcp](https://glama.ai/mcp/servers/@krunal16-c/gov-ca-mcp) | Government of Canada (250,000+ datasets) | stdio | [@krunal16-c](https://github.com/krunal16-c) | Active | Two servers: datasets and transportation (bridges, airports, cycling, transit, railways). |
+| [gov-ca-mcp](https://github.com/krunal16-c/gov-ca-mcp) | Government of Canada (250,000+ datasets) | stdio | [@krunal16-c](https://github.com/krunal16-c) | Active | Two servers: datasets and transportation (bridges, airports, cycling, transit, railways). |
 | [ibge-mcp](https://github.com/SidneyBissoli/ibge-br-mcp) | IBGE (Brazilian census/statistics) | stdio | [@SidneyBissoli](https://github.com/SidneyBissoli) | Active | 23 tools. Demographics, geography, economics, SIDRA tables, population projections. |
-| [bcb-mcp](https://lobehub.com/mcp/sidneybissoli-bcb-br-mcp) | Brazil Central Bank | stdio | [@SidneyBissoli](https://github.com/SidneyBissoli) | Active | Selic, IPCA, exchange rates, GDP time series. |
-| [agrobr-mcp](https://github.com/bruno-portfolio/agrobr-mcp) | Brazilian agriculture (19 sources) | stdio | [@bruno-portfolio](https://github.com/bruno-portfolio) | Active | CEPEA, CONAB, IBGE, INPE, B3. Prices, crop estimates, climate, deforestation. |
+| [bcb-mcp](https://github.com/SidneyBissoli/bcb-br-mcp) | Brazil Central Bank | stdio | [@SidneyBissoli](https://github.com/SidneyBissoli) | Active | Selic, IPCA, exchange rates, GDP time series. |
+| [agrobr-mcp](https://github.com/bruno-portfolio/agrobr-mcp) | Brazilian agriculture (10 sources) | stdio | [@bruno-portfolio](https://github.com/bruno-portfolio) | Active | CEPEA, CONAB, IBGE, INPE, B3. Prices, crop estimates, climate, deforestation. |
 
 ### Global
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [world-bank-data-mcp](https://github.com/llnormll/world-bank-data-mcp) | World Bank Data360 | stdio | [@llnormll](https://github.com/llnormll) | Active | 1,000+ indicators, 200+ countries. WDI, HNP, GDF, IDS datasets. |
+| [world-bank-data-mcp](https://github.com/llnOrmll/world-bank-data-mcp) | World Bank Data360 | stdio | [@llnOrmll](https://github.com/llnOrmll) | Active | 1,000+ indicators, 200+ countries. WDI, HNP, GDF, IDS datasets. |
 
 ## Framework / Multi-Portal Servers
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [OpenDataMCP](https://github.com/OpenDataMCP/OpenDataMCP) | Universal open data portals | stdio | [@OpenDataMCP](https://github.com/OpenDataMCP) | Active | Universal framework aiming to connect any open data portal to any LLM via MCP. Starting with Switzerland. |
+| [OpenDataMCP](https://github.com/OpenDataMCP/OpenDataMCP) | Universal open data portals | stdio | [@OpenDataMCP](https://github.com/OpenDataMCP) | Inactive | Universal framework aiming to connect any open data portal to any LLM via MCP. Starting with Switzerland. No repository commits since 2024-12-20 (verified 2026-08-12). |
 
 ## CKAN Servers
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [ckan-mcp-server (ondata)](https://github.com/ondata/ckan-mcp-server) | Any CKAN portal worldwide | stdio | [@ondata](https://github.com/ondata) | Active | Generic CKAN connector. Works with data.gov, data.gov.uk, data.europa.eu, and hundreds more. Docs. |
+| [ckan-mcp-server (ondata)](https://github.com/ondata/ckan-mcp-server) | Any CKAN portal worldwide | stdio, http | [@ondata](https://github.com/ondata) | Active | Generic CKAN connector. Works with data.gov, data.gov.uk, data.europa.eu, and hundreds more. Docs. |
 | [ckan-mcp-server (ondics)](https://github.com/ondics/ckan-mcp-server) | Any CKAN portal | stdio | [@ondics](https://github.com/ondics) | Active | Alternative CKAN implementation. Browsing and management. |
 | [ckan-mcp (OpenASCOT)](https://glama.ai/mcp/servers/@openascot/ckan-mcp) | 600+ global CKAN portals | stdio | [@openascot](https://github.com/openascot) | Active | Exposes 600+ portals to AI assistants. |
 
@@ -165,7 +166,7 @@ A directory of MCP servers for accessing civic and public data. Servers marked *
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [gis-mcp](https://github.com/mahdin75/gis-mcp) | GIS operations | stdio | [@mahdin75](https://github.com/mahdin75) | Active | Shapely, PyProj, GeoPandas, Rasterio, PySAL. Geometry, coordinate transforms, spatial analysis. |
+| [gis-mcp](https://github.com/mahdin75/gis-mcp) | GIS operations | stdio, http | [@mahdin75](https://github.com/mahdin75) | Active | Shapely, PyProj, GeoPandas, Rasterio, PySAL. Geometry, coordinate transforms, spatial analysis. |
 | [osmmcp](https://github.com/NERVsystems/osmmcp) | OpenStreetMap | stdio | [@NERVsystems](https://github.com/NERVsystems) | Active | 25 tools: geocoding, routing, nearby places, neighborhood analysis. No keys required. |
 | [mapbox-mcp](https://github.com/mapbox/mcp-server) | Mapbox | stdio | Mapbox (official) | Active | Geocoding, POI search, routing, travel time, isochrones. |
 
@@ -173,24 +174,24 @@ A directory of MCP servers for accessing civic and public data. Servers marked *
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [open-meteo-mcp](https://github.com/cmer81/open-meteo-mcp) | Open-Meteo (weather, climate) | stdio | [@cmer81](https://github.com/cmer81) | Active | 7-day forecasts, ERA5 historical data from 1940, air quality, marine, CMIP6 climate projections. No API key. |
+| [open-meteo-mcp](https://github.com/cmer81/open-meteo-mcp) | Open-Meteo (weather, climate) | stdio, http | [@cmer81](https://github.com/cmer81) | Active | 7-day forecasts, ERA5 historical data from 1940, air quality, marine, CMIP6 climate projections. No API key. |
 
 ## Other Civic-Adjacent Servers
 
 | Server | Data Source | Transport | Maintainer | Status | Notes |
 |--------|------------|-----------|------------|--------|-------|
-| [NASA-MCP-server](https://github.com/ProgramComputer/NASA-MCP-server) | 20+ NASA APIs | stdio | [@ProgramComputer](https://github.com/ProgramComputer) | Active | APOD, Mars Rover, EPIC earth imagery, NEO, EONET, DONKI, GIBS, POWER, JPL. |
-| [patent-mcp](https://github.com/riemannzeta/patent_mcp_server) | USPTO Patents | stdio | [@riemannzeta](https://github.com/riemannzeta) | Active | Patent Public Search, PTAB, PatentsView, Office Action, Patent Litigation. |
-| [mcp-nutrition-tools](https://mcpservers.org/servers/zen-apps/mcp-nutrition-tools) | USDA FoodData Central | stdio | [@zen-apps](https://github.com/zen-apps) | Active | 600,000+ foods. CC0 public domain. |
+| [NASA-MCP-server](https://github.com/ProgramComputer/NASA-MCP-server) | 20+ NASA APIs | stdio, http | [@ProgramComputer](https://github.com/ProgramComputer) | Active | APOD, Mars Rover, EPIC earth imagery, NEO, EONET, DONKI, GIBS, POWER, JPL. |
+| [patent-mcp](https://github.com/riemannzeta/patent_mcp_server) | USPTO Patents | stdio, http | [@riemannzeta](https://github.com/riemannzeta) | Active | Patent Public Search, PTAB, PatentsView, Office Action, Patent Litigation. |
+| [mcp-nutrition-tools](https://github.com/zen-apps/mcp-nutrition-tools) | USDA FoodData Central | stdio | [@zen-apps](https://github.com/zen-apps) | Active | 600,000+ foods. CC0 public domain. |
 | [mcp-wikidata](https://github.com/zzaebok/mcp-wikidata) | Wikidata | stdio | [@zzaebok](https://github.com/zzaebok) | Active | Entity search, property retrieval, SPARQL queries. Runs on Cloudflare Workers. |
 | [foiagras](https://foiagras.com/mcp/) | Government transparency / FOIA | stdio | FOIA Gras | Active | Public records, meeting minutes, local government documents. |
-| [civicnet-mcp-server](https://github.com/Publik-Works/civicnet-mcp-server) | Federated civic infrastructure | stdio | [@Publik-Works](https://github.com/Publik-Works) | Active | Federated civic infrastructure with equity principles. |
+| [civicnet-mcp-server](https://github.com/CivikNet/civicnet-mcp-server) | Federated civic infrastructure | stdio | [@CivikNet](https://github.com/CivikNet) | Inactive | Federated civic infrastructure with equity principles. No repository commits since 2025-06-04 (verified 2026-08-12). |
 
 ---
 
 ## Coverage Gaps
 
-The following civic data domains have **no or limited MCP server coverage** as of March 2026:
+The following civic data domains have **no or limited MCP server coverage** as of August 2026:
 
 | Domain | Data Sources That Could Be Wrapped | Notes |
 |--------|-----------------------------------|-------|
@@ -212,7 +213,7 @@ Servers ranked by value to civic-ai-tools users, considering data breadth, quali
 
 2. **[census-mcp (official)](https://github.com/uscensusbureau/us-census-bureau-data-api-mcp)** — Official Census Bureau server. ACS data is foundational for almost all civic analysis. Maintained by the agency itself.
 
-3. **[us-gov-open-data-mcp](https://github.com/lzinga/us-gov-open-data-mcp)** — 36+ APIs, 188+ tools. Covers EPA, NOAA, FDA, SEC, BLS, and more in a single server. Modular loading lets users enable only the APIs they need.
+3. **[us-gov-open-data-mcp](https://github.com/lzinga/us-gov-open-data-mcp)** — 40+ APIs, 300+ tools. Covers EPA, NOAA, FDA, SEC, BLS, and more in a single server. Modular loading lets users enable only the APIs they need.
 
 ### Tier 2: High Value, More Specialized
 
@@ -232,7 +233,7 @@ Servers ranked by value to civic-ai-tools users, considering data breadth, quali
 
 ### Integration Notes
 
-- Most servers use **stdio transport only** — they work with Claude Code, Cursor, and VS Code Copilot out of the box. Only socrata-mcp-server and datagouv-mcp offer HTTP transport for web applications.
+- **49 of the 70 servers listed are stdio-only** — they work with Claude Code, Cursor, and VS Code Copilot out of the box, but not with web applications. The other 21 document an HTTP or SSE transport; see the Transport column above for which.
 - Adding a new server to civic-ai-tools requires: (1) adding it to `claude_desktop_config.json`, (2) writing a skill guidance doc in `docs/skills/`, and (3) testing with representative queries.
 - The **us-gov-open-data-mcp** server's modular loading pattern is worth studying — it lets users enable only the APIs they need, avoiding tool overload.
 - **Two official U.S. federal agencies** (Census Bureau, GPO) and **two national governments** (France, India) now maintain MCP servers. This is a strong legitimacy signal for the ecosystem.

--- a/scripts/generate-directory-md.mjs
+++ b/scripts/generate-directory-md.mjs
@@ -13,6 +13,15 @@ const OUT_PATH = join(ROOT, 'docs', 'mcp-servers.md');
 
 const entries = JSON.parse(readFileSync(JSON_PATH, 'utf-8'));
 
+// --- Survey currency -------------------------------------------------------
+// The date the directory's entries were last checked against their sources.
+// Bump this — and re-run the survey it names — together; a stale date on a
+// page presented as current curation is the defect this constant exists to
+// make visible (#137). Month name and ISO date are both emitted so the human
+// header and any machine reader agree.
+const SURVEY_MONTH = 'August 2026';
+const SURVEY_DATE = '2026-08-12';
+
 // --- Section definitions (order matters) ---
 
 const SECTIONS = [
@@ -236,7 +245,13 @@ parts.push('# Civic Data MCP Servers');
 parts.push('');
 parts.push("A directory of MCP servers for accessing civic and public data. Servers marked **Included** are pre-configured in this repo's setup.");
 parts.push('');
-parts.push('*Last surveyed: March 2026. Sources: GitHub, official MCP Registry, Glama, PulseMCP, mcpservers.org, mcp.so, Smithery, LobeHub, Playbooks.*');
+parts.push(`*Last surveyed: ${SURVEY_MONTH} (${SURVEY_DATE}). Sources: GitHub, official MCP Registry, Glama, PulseMCP, mcpservers.org, mcp.so, Smithery, LobeHub, Playbooks.*`);
+parts.push('');
+parts.push(
+  `**This is a point-in-time survey, not a live status feed.** Every entry below states what was true on ${SURVEY_DATE}; ` +
+    'projects are archived, renamed, and revived between surveys. Check the linked repository before relying on an entry, ' +
+    'and open an issue if you find one that has drifted.'
+);
 
 for (const section of SECTIONS) {
   const rendered = renderSection(section);
@@ -249,7 +264,7 @@ parts.push('---');
 parts.push('');
 parts.push('## Coverage Gaps');
 parts.push('');
-parts.push('The following civic data domains have **no or limited MCP server coverage** as of March 2026:');
+parts.push(`The following civic data domains have **no or limited MCP server coverage** as of ${SURVEY_MONTH}:`);
 parts.push('');
 parts.push('| Domain | Data Sources That Could Be Wrapped | Notes |');
 parts.push('|--------|-----------------------------------|-------|');
@@ -273,7 +288,7 @@ parts.push('1. **[ckan-mcp-server (ondata)](https://github.com/ondata/ckan-mcp-s
 parts.push('');
 parts.push('2. **[census-mcp (official)](https://github.com/uscensusbureau/us-census-bureau-data-api-mcp)** — Official Census Bureau server. ACS data is foundational for almost all civic analysis. Maintained by the agency itself.');
 parts.push('');
-parts.push('3. **[us-gov-open-data-mcp](https://github.com/lzinga/us-gov-open-data-mcp)** — 36+ APIs, 188+ tools. Covers EPA, NOAA, FDA, SEC, BLS, and more in a single server. Modular loading lets users enable only the APIs they need.');
+parts.push('3. **[us-gov-open-data-mcp](https://github.com/lzinga/us-gov-open-data-mcp)** — 40+ APIs, 300+ tools. Covers EPA, NOAA, FDA, SEC, BLS, and more in a single server. Modular loading lets users enable only the APIs they need.');
 parts.push('');
 parts.push('### Tier 2: High Value, More Specialized');
 parts.push('');
@@ -293,7 +308,17 @@ parts.push('9. **International data servers** — Spain (datos-gob-es), Sweden (
 parts.push('');
 parts.push('### Integration Notes');
 parts.push('');
-parts.push('- Most servers use **stdio transport only** — they work with Claude Code, Cursor, and VS Code Copilot out of the box. Only socrata-mcp-server and datagouv-mcp offer HTTP transport for web applications.');
+// Derived from the data rather than restated by hand: this sentence was
+// wrong before #137 (it named two servers when the data already listed
+// several), and a hand-maintained count goes stale the moment an entry
+// changes transport.
+const remoteCapable = entries.filter((e) => e.transport.some((t) => t !== 'stdio'));
+const stdioOnly = entries.length - remoteCapable.length;
+parts.push(
+  `- **${stdioOnly} of the ${entries.length} servers listed are stdio-only** — they work with Claude Code, Cursor, ` +
+    `and VS Code Copilot out of the box, but not with web applications. The other ${remoteCapable.length} document an ` +
+    'HTTP or SSE transport; see the Transport column above for which.'
+);
 parts.push('- Adding a new server to civic-ai-tools requires: (1) adding it to `claude_desktop_config.json`, (2) writing a skill guidance doc in `docs/skills/`, and (3) testing with representative queries.');
 parts.push("- The **us-gov-open-data-mcp** server's modular loading pattern is worth studying — it lets users enable only the APIs they need, avoiding tool overload.");
 parts.push('- **Two official U.S. federal agencies** (Census Bureau, GPO) and **two national governments** (France, India) now maintain MCP servers. This is a strong legitimacy signal for the ecosystem.');


### PR DESCRIPTION
Closes #137

`docs/mcp-servers.md` said **Last surveyed: March 2026** on a page presented as current curation. This re-verifies all 71 entries against their sources and regenerates the markdown from the data.

**Survey completed 2026-08-12.** Everything below rests on a request made during this survey (GitHub REST API, repository READMEs via the contents API, and the npm registry). Where a source was outside the survey environment's network reach, the field was **left exactly as it was** and is listed under *Could not verify* — no inference from names, no "probably abandoned."

## Method

- 57 of 71 entries link to a GitHub repository: each fetched via `GET /repos/{owner}/{repo}` for existence, `archived`, `pushed_at`, canonical `full_name`, license, and description; READMEs fetched via `GET /repos/{owner}/{repo}/readme`.
- 4 npm packages (`socrata-mcp-server`, the three `@betanyc/*`) plus `opengov-mcp-server` checked on registry.npmjs.org: all present, none deprecated.
- 14 entries link to an aggregator page or a vendor site rather than a repository. Those hosts were unreachable; see *Could not verify*.
- `docs/mcp-servers.md` was **not** hand-edited. Before making changes I confirmed the generator reproduces the committed markdown **byte-for-byte** from the pre-change data, so the entire markdown diff is attributable to the data + generator diffs. No reordering or formatting churn.

## What changed, per entry

### Removed (1)

| Entry | Evidence |
|---|---|
| `odp-mcp` | `https://github.com/socrata/odp-mcp` → **404** (authenticated API, re-confirmed 2026-08-12T10:48Z). The `socrata` org is live and public with 66 public repos, **none** of them an MCP server. GitHub answers a *transfer* with 301, so this is a deletion or a switch to private — either way the directory's link is dead. Removing rather than keeping a 404 in a curated public index; see *Judgment calls*. |

### Status changes (7)

| Entry | Change | Evidence |
|---|---|---|
| `swedish-law-mcp` | Active → **Archived** | GitHub `archived: true`; last commit 2026-07-07. The maintainer archived essentially their whole MCP fleet, including the Danish- and Finnish-law servers the old note pointed at (`Danish-law-mcp`, `Finnish-law-mcp`: both `archived: true`). Description narrowed from "Swedish, Danish, Finnish law" to "Swedish statutes and regulations" — the repo's own description is *"MCP server for Swedish statutes and regulations"*; the Danish/Finnish claim was about sibling repos, not this server. |
| `opendatamcp` | Active → **Inactive** | `pushed_at` 2024-12-20 (~20 months) |
| `opengov-mcp-server` | Active → **Inactive** | `pushed_at` 2025-04-09 (~16 months) |
| `datagov-mcp-server` | Active → **Inactive** | `pushed_at` 2025-04-09 (~16 months) |
| `civicnet-mcp-server` | Active → **Inactive** | `pushed_at` 2025-06-04 (~14 months) |
| `opendart-mcp` | Active → **Inactive** | `pushed_at` 2025-06-22 (~14 months) |
| `congress-gov-mcp` | Active → **Inactive** | `pushed_at` 2025-06-30 (~14 months) |

Each of those six carries the observed date in its note ("No repository commits since YYYY-MM-DD (verified 2026-08-12)") so the reader can check the claim rather than take the label on faith. None is archived upstream — the rule applied was purely *no commits in over 12 months*. See *Judgment calls*.

### Repository moved (1)

| Entry | Change | Evidence |
|---|---|---|
| `civicnet-mcp-server` | `Publik-Works/…` → `CivikNet/civicnet-mcp-server`; maintainer `Publik-Works` → `CivikNet` | GitHub **301** redirect to the new org |

### Transport corrections (14)

Each of these advertised **stdio only** while its own README documents a remote transport. This is the column a web-integrating reader relies on, so it is quoted evidence in every case.

| Entry | Now | README evidence |
|---|---|---|
| `us-gov-open-data-mcp` | + http | "Dual transport — stdio for desktop clients, HTTP Stream for web/remote" |
| `capture-mcp-server` | + http | "runs in HTTP mode (StreamableHTTP transport) when `MCP_TRANSPORT=http`" |
| `congressmcp` | + http | `congressmcp --transport streamable-http --port 8000`; `MCP_TRANSPORT` = `stdio` or `streamable-http` |
| `courtlistener-mcp` | + http | config sample with `"transport": "streamable-http"` against a deployed worker |
| `fred-mcp-server` | + http | "### Using Streamable HTTP Transport … `TRANSPORT=http node build/index.js`" |
| `sec-edgar-mcp` | + http | "## HTTP Transport … `--transport streamable-http --port 9870`" |
| `estat-mcp` | + **sse** | `estat-mcp serve [--transport stdio\|sse]` |
| `mcp-datagovmy` | + http | hosted endpoint config with `"transport": "streamable-http"` |
| `budgetkey-mcp` | + http | client config `{"type": "http", "url": "https://next.obudget.org/mcp"}` |
| `ckan-mcp-server` (ondata) | + http | "Hosted endpoint: `…workers.dev/mcp`", with all examples documented for both local and hosted |
| `gis-mcp` | + http | Transport badge "HTTP \| stdio"; "Both Dockerfiles have HTTP transport mode enabled by default … `http://localhost:9010/mcp`" |
| `open-meteo-mcp` | + http | "### Streamable HTTP Transport … `TRANSPORT=http PORT=3000 npx …`" |
| `nasa-mcp-server` | + http | `MCP_TRANSPORT` — "`stdio` (default) or `http` for Streamable HTTP" |
| `patent-mcp-server` | + http | `MCP_TRANSPORT=stdio # stdio (default) or streamable-http` |

Transport claims in the **other** direction were spot-checked too, and hold: `usaspending-mcp-server` ("stateless streamable HTTP MCP server", first line of its README), `gov-mcp-servers` ("MCP over stdio (Glama/local) or Streamable HTTP (Apify)"), `datagouv-mcp` (`claude mcp add --transport http` plus an `npx` stdio config).

### Link targets repointed at the source repository (4)

Each of these linked to an aggregator listing whose URL *names* a GitHub repo. Repointing at the repo replaces a third-party index page with the project's own home and makes the entry mechanically verifiable in future surveys. Adopted only where the repository's content matches the entry:

| Entry | Now | Match evidence |
|---|---|---|
| `umbrella-terminal-mcp` | `TheBlackCompany/umbrella_terminal_mcp` | README: *"MCP server for Colorado legislative intelligence. Provides 67 tools for querying bills, statutes, rules … campaign finance"* — matches the entry's description and its `toolCount: 67` exactly |
| `gov-ca-mcp` | `krunal16-c/gov-ca-mcp` | repo description: *"Python-based MCP **servers** for accessing Canada's Open Government data"* — matches "Two servers: datasets and transportation" |
| `bcb-mcp` | `SidneyBissoli/bcb-br-mcp` | repo description: *"Brazil Central Bank (BCB) data — Selic, IPCA, exchange rates, GDP"* — matches the note verbatim |
| `mcp-nutrition-tools` | `zen-apps/mcp-nutrition-tools` | repo description: *"USDA's 600k+ food database"* — matches "600,000+ foods" |

Four other aggregator URLs name a GitHub path that does **not** exist (`forest-builds/nyc-mcp`, `openascot/ckan-mcp`, `tonychan/data-gov-hk`, `ezbiz-services/gov-con` all 404). That is not evidence those projects are gone — aggregators list servers whose repo is named differently or is not on GitHub at all — so those entries were left untouched.

### repoUrl casing canonicalised (5)

GitHub URLs are case-insensitive, so nothing was broken; these now match the API's `full_name` so future surveys diff cleanly.

`congress-gov-mcp` → `AshwinSundar/…` · `riksdag-regering-mcp` → `isakskogstad/Riksdag-Regering-MCP` · `swedish-law-mcp` → `Ansvar-Systems/Swedish-law-mcp` · `budgetkey-mcp` → `OpenBudget/…` (maintainer too) · `world-bank-data-mcp` → `llnOrmll/…` (maintainer too).

### Scale claims restated from the project's own words (3)

| Entry | Change | Evidence |
|---|---|---|
| `us-gov-open-data-mcp` | "36+ federal APIs" → **40+**; `toolCount` 188 → **300**; "18 APIs need no key" → **20+** | README: *"300+ tools across 40+ government APIs"*, *"20+ APIs require no key"*. Note: the repo **description** says "250+ tools" while the README says "300+" twice — I used the README. Flagging the discrepancy rather than hiding it. |
| `agrobr-mcp` | "19 sources" → **10 sources** | README: *"10 public sources from agrobr"*; repo description says the same. A decrease, so worth a second look — but it is the maintainer's own current statement in two places. |
| `opengov-mcp-server` | dropped "~10 stars" | Actual count is 14. Rather than restate a number that is wrong again next week, I removed it: it was the only star claim in the file. |

`dateModified` was set to `2026-08-12` on the 28 changed entries only, so the diff stays reviewable. Unchanged entries were re-verified too — that fact lives in the survey date in the header, which is what it is for.

## Could not verify

The survey environment could reach `github.com`, `api.github.com`, `registry.npmjs.org` and `objects.githubusercontent.com`, and nothing else. **Everything in this list was left exactly as it was.**

1. **10 entries whose link is not a GitHub repository** — existence, activity, and status all unverified: `nyc-mcp` (lobehub.com), `mimilabs` (mimilabs.ai), `pophive-mcp` (pophive.yale.edu), `govcon-mcp` (glama.ai), `govtribe-mcp` (blog.govtribe.com), `india-nso-mcp` (pib.gov.in), `govuk-mcp` (stealthlabs.ai), `data-gov-hk-mcp` (pulsemcp.com), `ckan-mcp-openascot` (glama.ai), `foiagras` (foiagras.com).
2. **Whether hosted endpoints are actually live.** For the transport corrections above I verified the transport is *documented*, not that any URL responds — including `api.datacommons.org/mcp`, `next.obudget.org/mcp`, `mcp.data.gouv.fr/mcp`, the ondata `workers.dev` endpoint, and our own `socrata-mcp.civicaitools.org`.
3. **Whether `socrata/odp-mcp` was deleted or made private.** GitHub returns 404 for both. All I can assert is *not publicly reachable, and not transferred*.
4. **`kolada-mcp` transport.** Its repo description says "via remote server URL or local installation", but its README (Swedish) documents only stdio config. Ambiguous → left `stdio`.
5. **`gis-mcp` SSE.** A README bullet reads "HTTP/SSE Transport"; the Docker/config sections document only HTTP. I added `http` only.
6. **`swedish-law-mcp` HTTP.** Its README documents `--transport http https://gateway.ansvar.eu/mcp`, but the repo is archived and I could not reach the gateway. Did not add a transport claim I cannot confirm is live.
7. **`boston-core-mcp` and `opencontext` transport (`http`, no stdio).** Neither README states a transport in terms I could confirm. Left as-is.
8. **`mcp-nutrition-tools` transport.** Its description mentions "dual architecture (MCP protocol + HTTP API)" — an HTTP *API* is not necessarily an MCP HTTP transport. Left `stdio`.
9. **`govinfo-mcp`.** `repoUrl` points at `usgpo/api` (live, 264 stars, pushed 2026-07-21), which is a docs repo rather than the server; the govinfo.gov MCP preview page was unreachable. Left as-is, still Beta.
10. **Numeric scale claims other than the two restated above** — `courtlistener-mcp` "3,352 U.S. courts", `sec-edgar-mcp` "13M+ filings", `fred-mcp-server` "800,000+ series", `gov-ca-mcp` and the ondata Tier-1 blurb "250,000+ datasets", `estat-mcp` "3,000+ tables", `kolada-mcp` "5,000+ KPIs", `datos-gob-es-mcp` "40,000+ datasets", `nyc-mcp` "2,000+ datasets", and per-entry `toolCount` values generally. Verifying these means counting from source, not reading a header. Left untouched. (`mcp-civic-data` says "7 federal APIs" and then lists six — worth a look, but I could not establish the right number, so I did not touch it.)

## Proposed additions

**None added.** This was a re-verification pass, not an expansion, and I would rather not pad a directory whose value is that its entries have been checked. One candidate for your judgment:

- **[`Thomas-TyTech/odp-mcp`](https://github.com/Thomas-TyTech/odp-mcp)** — *"MCP server for Socrata SODA API"*, created 2025-12-10, last push 2025-12-10, 0 stars, not a fork. Same owner as the existing `Socrata-MCP` entry ("from a Tyler Technologies developer"), so it may be where the removed `socrata/odp-mcp` went. **I did not add it or repoint the removed entry at it**: I have no evidence linking the two repos, and its last push is 8 months old. If you know the history, one line of data restores the entry.

## Generator changes — yes, four

1. **`SURVEY_MONTH` / `SURVEY_DATE` constants** replace two independently hardcoded "March 2026" strings (the header and the Coverage Gaps line), which could previously drift apart. Bumping the survey now means editing one place.
2. **Explicit point-in-time caveat in the header**, which is what #137 asked us to consider: *"This is a point-in-time survey, not a live status feed. Every entry below states what was true on 2026-08-12; projects are archived, renamed, and revived between surveys."* The freshness contract is now stated in the output rather than implied by a date.
3. **The HTTP-transport line in Integration Notes is now derived from the data.** It previously read *"Only socrata-mcp-server and datagouv-mcp offer HTTP transport"* — already contradicted by the repo's own data before this PR (seven entries carried `http`), and it would have gone further wrong with this survey's transport fixes. It now computes the counts.
4. **Tier-1 blurb for `us-gov-open-data-mcp`** updated from "36+ APIs, 188+ tools" to match the corrected data.

The survey date lives in the generator rather than in `data/mcp-servers.json` because the JSON's **top-level array shape is a live contract**: `civic-ai-tools-website` fetches this exact file from `raw.githubusercontent.com` at build time (`src/lib/site-config.ts`) and `src/lib/mcp/directory-data.ts` expects a bare array. Wrapping it in an object to carry metadata would break `/directory` on the site — including any fork configured via #245. Worth a follow-up: a machine-readable survey date (top-level object, or a sidecar `data/directory-survey.json`) would let the website's `/directory` page state its own freshness, which it currently cannot. That is a cross-repo change and I left it out of this PR.

## Judgment calls, so you can overrule them cheaply

1. **Removing `odp-mcp` rather than marking it Inactive.** The status vocabulary has no "gone" value, and keeping it would leave a 404 in a public curated index — a live wrong claim, which the accuracy bar for this file ranks worse than a stale one. Restoring it is one JSON object.
2. **The 12-month dormancy rule.** "No commits in over 12 months" is a fact; calling a project *Inactive* is an interpretation, and a small server that works may simply not need commits. I applied one uniform threshold, recorded the underlying date in each note, and touched nothing between 9 and 12 months (`open-data-mcp` 2025-11-04, `socrata-mcp` 2025-11-07, `boston-core-mcp` 2025-12-03 all stay Active). Flip any of the six back by changing one field.
3. **Repointing four aggregator URLs at GitHub.** Better link targets and future verifiability, but it does change what a reader clicks through to.
4. **Dropping the star count** rather than updating it to 14.
5. **Fixing the Integration Notes transport sentence.** Editorial content, strictly beyond "refresh the survey" — but it was factually wrong against the repo's own data, and this PR made it wronger.

## Verification

- `npm run validate-directory` → 70 entries, all valid.
- `npm run generate-directory-md` → 70/70 placed; re-running produces an identical file.
- Baseline check: the pre-change generator + pre-change data reproduce the committed `docs/mcp-servers.md` **byte-for-byte**, so no part of the markdown diff is unrelated churn.
- CI steps run locally on Node v22.23.1: `build`, `test` (113 pass), `typecheck`, `lint`, `check:budgets:self-test` (9 pass), `check:budgets`, `check:skill-drift:self-test` (29 pass) — all green. `check:skill-drift` itself fails locally **only** because `raw.githubusercontent.com` was outside the survey environment's network allowlist; this PR touches no file under `docs/skills/` (`git diff --name-only -- docs/skills` is empty), so it should pass in Actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
