### PR TITLE
test(harness): supply visibility to buildCommitmentView — produce-core 0.2.1 requires it

### DIFF
--- a/packages/civic-typed-harness/src/composition-roundtrip.test.ts
+++ b/packages/civic-typed-harness/src/composition-roundtrip.test.ts
@@ -308,6 +308,11 @@ function produceSignedPackage() {
   const sidecar = buildCommitmentView({
     packageHash: assembled.envelopeHash,
     packageUrl: 'https://packages.example.org/evidence/example.json',
+    // Fully disclosed view (no redactContentSurface; packageUrl/subjectTitle/
+    // subjectSummary are all present below) — ADR-0016 §A vocabulary: 'public',
+    // not 'sealed' (which pairs with a redacted view). produce-core 0.2.1
+    // (ADR-0024) throws when visibility is omitted instead of defaulting it.
+    visibility: 'public',
     captureMethod: 'chat-flow-stream',
     producerProfile: assembled.pkg.producerProfile,
     type: assembled.pkg.type,


### PR DESCRIPTION
## Why this is needed

`@typedstandards/produce-core` is about to release **0.2.1**, which makes `buildCommitmentView` **throw** when `visibility` is absent instead of silently defaulting it to `'published'` (ADR-0024: a default must not assert a disclosure state nobody supplied).

The harness's composition round-trip test calls `buildCommitmentView` at `packages/civic-typed-harness/src/composition-roundtrip.test.ts:308` without supplying `visibility`. The harness pins `"@typedstandards/produce-core": "^0.2.0"`, a range that resolves to 0.2.1 once it publishes, so CI would start failing on the next install after that release — before anyone touches this repo again.

## Why it's safe to land now, before the release

Supplying an explicit `visibility` value behaves identically under both versions:
- **0.2.0** (currently installed, tested against): the default path in `commitment.js` — `visibility: input.visibility ?? 'published'` — simply never fires when the value is supplied; behavior is unchanged.
- **0.2.1** (post-release): the same explicit value satisfies the new required-value check, so the call no longer throws.

This PR is test-only: no runtime source, `package.json`, or dependency range in the harness is touched.

## Value chosen and reasoning

Set `visibility: 'public'`.

The vocabulary of record (ADR-0016 §A, owner-confirmed 2026-08-12) is `sealed` | `public` — `published` is a permanent *input alias*, not a value to introduce into new code.

The test's `buildCommitmentView` call does not set `redactContentSurface`, and it supplies `packageUrl`, `subjectTitle`, and `subjectSummary` all at once — i.e. it demonstrates a **fully disclosed, non-redacted** commitment view. Per `commitment.js`, `redactContentSurface: true` is what triggers redaction of `packageUrl`/`subjectTitle`/`subjectSummary`; this test exercises the opposite path. `'public'` is therefore the value that matches what the test is actually demonstrating; `'sealed'` would misrepresent it.

## Did any assertion depend on the old implicit default?

No. Two checks confirmed this:

1. **What `visibility` does in `buildCommitmentView`**: read the installed 0.2.0 `commitment.js` — `visibility` is only ever echoed verbatim into the returned sidecar object (`visibility: input.visibility ?? 'published'`). It plays no role in the redaction branches (those key off `redactContentSurface` only).
2. **What the test does with the sidecar**: in `composition-roundtrip.test.ts`, only `sidecar.packageHash` and `sidecar.signature` are read back out (fed into `verifyEvidence(...)`). No assertion anywhere in the file reads `sidecar.visibility`. (The unrelated `promptVisibility: 'full_text'` field at line 233 is a distinct `EnvelopeInput` field — `'full_text' | 'hash_only'` — not the `CommitmentViewInput.visibility` this PR touches.)

No expectation needed updating.

## Other call sites — confirmed none

Grepped the whole harness package (`packages/civic-typed-harness/src`, excluding `node_modules`):

- `buildCommitmentView` — exactly **one** call site: this test, line 308. No other occurrence anywhere in `src/`.
- Every other `@typedstandards/produce-core` import in the harness (`buildEnvelope`, `sha256Hex`, `isBlobRef`, the PROV-O helpers in `format/vocabulary.ts`) was checked against the installed `.d.ts` signatures. None of those relies on an optional-with-default field the way `buildCommitmentView`'s `visibility` did — `EnvelopeInput.promptVisibility` (the one visibility-adjacent field on `buildEnvelope`) is a **required** field and is always supplied explicitly in this test (`'full_text'`).

This confirms the release is safe for the harness afterward: this is the only touch point.

## Versions tested

- `@typedstandards/produce-core@0.2.0` (from npm — expected, since 0.2.1 isn't published yet). This is deliberate: the change must pass on both 0.2.0 and 0.2.1, and passing on 0.2.0 today is what proves it's safe to land ahead of the release.

## Test results (harness `packages/civic-typed-harness`, mirroring `.github/workflows/ci.yml`)

- `npm run build` — pass
- `npm test` — **113/113 pass** (includes `composition-roundtrip.test.ts` and `golden-reproduction.test.ts`)
- `npm run typecheck` — pass, no errors
- `npm run lint` — pass, no errors
- `npm run check:budgets:self-test` — 9/9 pass
- `npm run check:budgets` — pass (`@typedstandards/civic-typed-harness — 10 source files, 7 bare imports, budget [@typedstandards/produce-core]`)
- `npm run check:skill-drift:self-test` — 29/29 pass (the live `check:skill-drift` fetch step was not run — network-dependent and unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
