### PR TITLE
docs(civic-typed-harness): warn against spreading the reference config

### DIFF
--- a/packages/civic-typed-harness/src/capture/provenance.ts
+++ b/packages/civic-typed-harness/src/capture/provenance.ts
@@ -93,7 +93,9 @@ export interface ProvenanceConfig {
 }
 
 /** The civicaitools.org reference deployment's values. Passed explicitly by
- *  the reference app — never applied as a default. */
+ *  the reference app — never applied as a default, and never spread into
+ *  another instance's config, which would assert infrastructure that
+ *  instance doesn't run. */
 export const CIVICAITOOLS_PROVENANCE_CONFIG: ProvenanceConfig = {
   platformAgent: CIVICAITOOLS_PLATFORM_AGENT,
   sourceRegistry: CIVIC_SOURCE_REGISTRY,


### PR DESCRIPTION
## Summary

`CIVICAITOOLS_PROVENANCE_CONFIG`'s doc-comment said the config is never applied as a *default*, but didn't say it must never be **spread into another instance's config** — the drift that actually happened (the website app spread this constant into every instance's provenance, so any deployment running that code asserted the reference deployment's gateway regardless of what it actually used). Website Wave N4 P3 fixed the website side; this phase writes the warning into the harness doc-comment so the next importer is told.

- Adds one clause to the doc-comment at `packages/civic-typed-harness/src/capture/provenance.ts:95-96`.
- `modelAgentDescription: 'Large language model via OpenRouter'` is unchanged — it is true of the reference deployment.
- No code line changed; diff is comment-only.

Anchor: https://github.com/npstorey/civic-ai-tools-website/issues/30 (Wave N4, P5)

## Test plan

All twelve check-set commands run green locally (`npm ci` first): `npm run build`, `npm test`, `npm run typecheck`, `npm run lint`, `npm run check:budgets:self-test`, `npm run check:budgets`, `npm run check:spec-frontmatter:self-test`, `npm run check:spec-frontmatter`, `npm run check:skill-drift:self-test`, `npm run check:skill-drift`, `python3 .claude/skills/publish-record/test_publish.py`. Full output pasted in the phase report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
