### PR TITLE
skills: base.md says what search and fetch do — one configured portal, no portal argument (#186)

### DIFF
--- a/docs/skills/base.md
+++ b/docs/skills/base.md
@@ -172,25 +172,37 @@ Then compute the diff per row and aggregate in code. State it explicitly: "Resol
 
 ## Domain Support
 
-**Any Socrata open data portal can be queried.** There are 500+ Socrata portals across the US and internationally. If the user asks about a city, state, or county, try it — use the `search` tool to discover datasets on that domain, or use `get_data` with the domain directly. Do NOT refuse a query just because a city isn't listed below.
+**Any Socrata open data portal can be queried.** There are 500+ Socrata portals across the US and internationally. If the user asks about a city, state, or county, try it — use `get_data` with `type: "catalog"` and that portal to discover its datasets, then `get_data` with `type: "query"` to read them. Do NOT refuse a query just because a city isn't listed below.
 
-To find a portal domain for a city, use common patterns: `data.cityofX.us`, `data.X.gov`, `data.Xcounty.gov`, `data.state.X.us`. If unsure, use the `search` tool with the city name.
+To find a portal domain for a city, use common patterns: `data.cityofX.us`, `data.X.gov`, `data.Xcounty.gov`, `data.state.X.us`. If you aren't sure which domain is right, try a candidate with `get_data` and `type: "catalog"`: one call either returns that portal's datasets or shows the portal isn't reachable.
+
+### Which Tool Reaches Which Portal
+
+**`get_data` is the only tool that takes a portal.** Settle that before choosing a tool:
+
+- **`get_data`** accepts a `portal` argument (`domain` is an accepted spelling of the same thing) and works against **any** Socrata portal. With `type: "catalog"` it is the cross-portal discovery path; with `type: "query"` it runs SoQL against the portal you name.
+- **`search`** takes exactly one argument, `query`, and searches **only the portal this server is configured for**. It has no portal argument, and anything else sent with it is rejected. Reach for it when the portal you want is the configured one; use `get_data` with `type: "catalog"` for every other portal.
+- **`fetch`** takes exactly one argument, `id`, and the portal travels inside that identifier. A `search` hit hands you `dataset:<portal>:<dataset_id>` (or `record:<portal>:<dataset_id>:<row_id>` for a single row), and a full dataset URL is also accepted — both name their portal. A **bare 4x4 ID names no portal**, so it resolves against the portal this server is configured for.
+
+So a dataset ID you learned somewhere else — from the tables below, from the curated directory, or from a web search — is reached with `get_data` and an explicit `portal`, not with a bare ID handed to `fetch`. If you don't know which portal this server is configured for, don't guess: name the portal you want on a `get_data` call.
 
 ### Well-Tested Domains
 
-These portals have been extensively tested. Tool compatibility notes:
+These portals have been extensively tested, and each has a dataset table further down. Coverage below is `get_data` coverage, because `get_data` is the tool that takes a portal:
 
-| Domain | get_data | search | fetch | Status |
-|--------|----------|--------|-------|--------|
-| `data.cityofnewyork.us` | Full | Full | Full | Fully Compatible |
-| `data.cityofchicago.org` | Full | Full | Full | Fully Compatible |
-| `data.sfgov.org` | Full | Limited | Unknown | Query-Preferred |
-| `data.seattle.gov` | Full | Full | Full | Fully Compatible |
-| `data.lacity.org` | Full | Limited | Fails | Query-Only |
+| Domain | City | get_data coverage |
+|--------|------|-------------------|
+| `data.cityofnewyork.us` | New York City | Full |
+| `data.cityofchicago.org` | Chicago | Full |
+| `data.sfgov.org` | San Francisco | Full |
+| `data.seattle.gov` | Seattle | Full |
+| `data.lacity.org` | Los Angeles | Full |
+
+`search` and `fetch` have no column here, because how they behave is not a property of the portal in the row: `search` covers only the portal this server is configured for, and a bare 4x4 given to `fetch` resolves against that same portal. Neither is a way to reach one of these portals when the server is configured for a different one.
 
 ### Other Portals
 
-For portals not listed above, start with `search` to discover available datasets, then use `get_data` to query them. Most Socrata portals support all three tools. If `search` or `fetch` fails on a particular portal, fall back to `get_data` with a known dataset ID.
+For portals not listed above, discover datasets with `get_data` — `type: "catalog"`, the portal, and a search phrase — then read them with `get_data` and `type: "query"`. `search` will not help here: it covers only the portal this server is configured for. If a catalog call turns up nothing usable, go straight to `type: "query"` with a known dataset ID and that portal.
 
 ### When a Portal Doesn't Work
 
@@ -202,12 +214,12 @@ Not every city uses Socrata — some use ESRI/ArcGIS, CKAN, or proprietary platf
 ### Domain-Specific Workarounds
 
 **San Francisco (`data.sfgov.org`):**
-- Search tool sometimes returns NYC data instead of SF
-- Use web search to find SF dataset IDs, then use `get_data`
+- `search` covers only the configured portal. On a server configured for a different city it returns that city's datasets, not SF's — results that look like an answer and are not SF data.
+- Discover SF datasets with `get_data`, `type: "catalog"`, `portal: "data.sfgov.org"`, then read them with `type: "query"` and the same portal.
 
 **Los Angeles (`data.lacity.org`):**
-- Only `get_data` works; search and fetch tools fail
-- Use web search to find LA dataset IDs, then use `get_data` exclusively
+- A bare LA 4x4 handed to `fetch` resolves against the configured portal rather than against LA, so it will not return the LA dataset unless this server is configured for LA.
+- Use `get_data` with `portal: "data.lacity.org"` — `type: "catalog"` to discover, `type: "query"` to read. The known IDs below can go straight into a query.
 
 **Known LA Dataset IDs:**
 - MyLA311 2025: `h73f-gn57`
@@ -237,7 +249,7 @@ Not every city uses Socrata — some use ESRI/ArcGIS, CKAN, or proprietary platf
 
 ## Key Datasets by Portal
 
-A full curated directory with ~20-30 datasets per portal is at [`docs/datasets.md`](https://github.com/npstorey/civic-ai-tools/blob/main/docs/datasets.md). Below are the most-used datasets per portal for quick reference. Use the MCP `search` tool for datasets not listed here.
+A full curated directory with ~20-30 datasets per portal is at [`docs/datasets.md`](https://github.com/npstorey/civic-ai-tools/blob/main/docs/datasets.md). Below are the most-used datasets per portal for quick reference. For datasets not listed here, use `get_data` with `type: "catalog"` and the portal you want; `search` covers only the portal this server is configured for.
 
 ### NYC (`data.cityofnewyork.us`)
 
@@ -289,7 +301,7 @@ A full curated directory with ~20-30 datasets per portal is at [`docs/datasets.m
 
 ### Los Angeles (`data.lacity.org`)
 
-**Note:** Only `get_data` works for LA — search and fetch tools fail.
+**Note:** Reach these with `get_data` and `portal: "data.lacity.org"`. A bare 4x4 handed to `fetch` resolves against the portal this server is configured for, so an LA ID will not resolve there.
 
 | Dataset | ID | Key Fields |
 |---------|----|------------|
@@ -325,11 +337,11 @@ A full curated directory with ~20-30 datasets per portal is at [`docs/datasets.m
 
 ## Socrata MCP Server Tools
 
-| Tool | Purpose | Returns |
-|------|---------|---------|
-| **search** | Find datasets or search within a dataset | Encoded IDs |
-| **fetch** | Retrieve full metadata or records | Complete data with metadata |
-| **get_data** | Execute SoQL queries (recommended) | Raw query results |
+| Tool | Arguments | Purpose | Returns |
+|------|-----------|---------|---------|
+| **search** | `query` only — no portal argument | Find datasets on the portal this server is configured for | Up to 10 hits, each with an `id` of the form `dataset:<portal>:<dataset_id>`, a title, a portal URL, a description snippet, and — where the dataset allows it — its columns and a few preview rows |
+| **fetch** | `id` only — the portal travels in the identifier; a bare 4x4 resolves against the configured portal | Retrieve one dataset's full metadata, or one record | Metadata and the column list, or the record |
+| **get_data** | `type`, `portal` (any portal), plus SoQL parameters | Catalog discovery and SoQL queries — the only tool that reaches a portal other than the configured one | Raw query results |
 
 ## Output Format Guidelines
 


### PR DESCRIPTION
Filing: #186 (family F7). Wave anchor: npstorey/civic-ai-tools-website#384, phase P-H2.
(No auto-close keyword: the website mirror of this text is a separate phase of the same wave.)

**The drift check is expected red on this PR until the embed lands.** Merge order for a three-surface
change is fixed by `.claude/rules/skill-docs.md`: the socrata embed first, then this source PR.
The embed PR is **npstorey/socrata-mcp-server#60**, rendered from this branch's commit with
`node scripts/check-skill-drift.mjs --emit`. `check:skill-drift` fetches
`socrata-mcp-server@main:src/skills/base.ts`, which does not yet carry the new bytes, so it fails on
`base` and passes on the other three. Re-run it after #60 merges rather than treating the red as a defect.

## The defect

The base guidance told the model something untrue about its own tools. It said to "use the `search`
tool to discover datasets on that domain"; it carried a per-domain table whose `search` and `fetch`
columns read Full / Limited / Unknown / Fails; it said "if `search` or `fetch` fails on a particular
portal, fall back to `get_data`". All of that describes `search` and `fetch` as per-portal tools.

They are not. Measured in npstorey/socrata-mcp-server at `fb6416b`, `src/tools/socrata-tools.ts`:

- **`:408-418`** — `searchJsonParameters`: `additionalProperties: false`, exactly one property
  (`query`), `required: ['query']`. There is no portal or domain argument, and anything else sent is rejected.
- **`:420-430`** — `fetchJsonParameters`: `additionalProperties: false`, exactly one property (`id`),
  `required: ['id']`.
- **`:762-773`** — `handleSearchTool` sets `const domain = getDefaultDomain()` and calls
  `handleCatalog({ query, domain, limit: 10, offset: 0 })`. `search` searches the one portal the server
  is configured for, and returns at most 10 hits.
- **`:29-32`** — `getDefaultDomain()` reads `DATA_PORTAL_URL` (with a built-in fallback) and strips the
  scheme. That one value is the portal `search` covers.
- **`:783, :785`** — a hit's `id` is `dataset:${domain}:${datasetId}`; its `url` is
  `https://${domain}/dataset/${datasetId}`.
- **`:640-716`** — `parseFetchIdentifier` accepts five identifier forms: the `dataset:`/`record:`
  prefixed form (`:646-673`), a dataset URL or scheme-less `host/path` (`:675-681`, via
  `tryParseUrlIdentifier` at `:604-638`), a bare 4x4 (`:683-689`), `<4x4>:<row_id>` (`:692-701`), and
  `<domain>:<4x4>` (`:703-709`). Three of those carry a portal **inside the identifier**; a bare 4x4
  does not, and resolves against `getDefaultDomain()` (`:686`, `:697`).
- **`:820-827` with `:175-181`** — `handleFetchTool` passes the parsed domain through to
  `handleDatasetMetadata`, which builds `https://${domain}`. A fully-qualified identifier therefore does
  reach the portal it names — a capability the new text keeps rather than deletes.
- **`:359-366`, `:471`** — `get_data` takes `domain`, with `portal` accepted as an alias. It is the
  cross-portal path: `type: "catalog"` to discover, `type: "query"` to run SoQL.

The website's own tool description already states this truth
(`civic-ai-tools-website/src/lib/mcp/tools.ts:105-111`: "This tool searches ONE portal: the one the
server is configured with. It takes no portal argument."). The model receives both texts in one context
window, and today they contradict each other. This PR makes the skill text agree with the server.

## What changed in `docs/skills/base.md`

- **New "Which Tool Reaches Which Portal" subsection** under Domain Support: `get_data` is the only tool
  that takes a portal; `search` takes only `query` and covers the configured portal; `fetch` takes only
  `id`, the portal travels inside the identifier, and a bare 4x4 resolves against the configured portal.
  Plus the practical consequence — a dataset ID learned elsewhere is reached with `get_data` and an
  explicit `portal`, not with a bare ID handed to `fetch`.
- **Domain Support intro and the portal-guessing paragraph** now route discovery through `get_data` +
  `type: "catalog"` instead of through `search`.
- **The well-tested-domains table keeps its value** — which portals are well tested — but loses its
  `search` and `fetch` columns. Those columns described a per-portal property of two tools that take no
  portal, so no honest value could be put in them: the observations behind "Limited", "Unknown" and
  "Fails" were made against a server configured for some *other* portal, which is not a measurement of
  those tools on a server configured for the row's portal. A note under the table says exactly that.
  The remaining columns are Domain, City, and `get_data` coverage (a City column so the table has a
  second column carrying information, matching the per-city dataset sections below).
- **"Other Portals"** now says to discover with `get_data` + `type: "catalog"` + portal, and that
  `search` will not help there.
- **The SF and LA workarounds** are restated as what they actually are. SF: `search` covers only the
  configured portal, so on a server configured for another city it returns that city's datasets rather
  than SF's — which is precisely the "returns NYC data instead of SF" symptom the old text recorded.
  LA: a bare LA 4x4 handed to `fetch` resolves against the configured portal, so it will not return the
  LA dataset. Both now point at `get_data` with an explicit `portal`. The known LA dataset IDs are untouched.
- **The LA note in Key Datasets** (`Only get_data works for LA — search and fetch tools fail`) and the
  **key-datasets intro** (`Use the MCP search tool for datasets not listed here`) are corrected the same way.
- **The tool table** gains an Arguments column and states each tool's real argument list and return shape,
  including that `search` returns up to 10 hits with `dataset:<portal>:<dataset_id>` ids and, where the
  dataset allows it, columns and preview rows.

No capability the server implements is removed; none it does not implement is invented. The document's
voice and its both-audiences constraints are preserved: absolute URLs only, no reference to another file
by filename in the new text, neutral phrasing throughout.

## Downstream: the website fallback (read-only here, for phase P5)

`civic-ai-tools-website/src/lib/mcp/socrata-skill.ts` at `bfdf619` carries a hand-shaped fallback of this
document. Every line there that mirrors a claim changed by this PR:

| Website line(s) @ `bfdf619` | Mirrors `base.md` (pre-change) |
|---|---|
| `:151` | `:175` — "use the search tool to discover datasets on that domain" |
| `:153` | `:177` — "If unsure, use the search tool with the city name" |
| `:157` | `:181` — "These portals have been extensively tested. Tool compatibility notes:" |
| `:159-165` | `:183-189` — the table header, separator, and five rows carrying the `search` / `fetch` columns |
| `:169` | `:193` — "start with search … If search or fetch fails on a particular portal" |
| `:181-182` | `:205-206` — the SF workaround |
| `:185-186` | `:209-210` — the LA workaround |
| `:216` | `:240` — "Use the MCP search tool for datasets not listed here" |
| `:268` | `:292` — "Only get_data works for LA — search and fetch tools fail" |
| `:304-308` | `:328-332` — the tool table (header, separator, and all three rows) |

The ORCH's measured list was `:151, :153, :159, :169, :185, :216, :268, :306, :307`. Confirmed, with
four corrections: `:157` and the table body `:160-165` belong with `:159`; `:182` belongs with `:181`
and `:186` with `:185` (each workaround is a two-line pair); and the tool-table change covers `:304-308`,
not only `:306-307`, because the header gains a column and the `get_data` row is reworded.

**Flag for P5, outside this PR's blast zone:** `socrata-skill.ts:412` (inside `getSkillForPortal`) carries
`Note: SF search sometimes returns incorrect results. Use dataset IDs directly:` — the same false claim on
a second website surface that has no counterpart in `base.md`, so nothing in this repo will ever correct it.
That is the `getSkillForPortal` blind spot the prompt-advertised-tools guard was extended for; P5 should
cover it.

## Checks run locally

| Command | Result |
|---|---|
| `npm ci` | `added 116 packages, and audited 118 packages`, `found 0 vulnerabilities` |
| `npm run build` | `tsc -p tsconfig.json`, exit 0 |
| `npm test` | `# pass 125` / `# fail 0` |
| `npm run typecheck` | no output, exit 0 |
| `npm run lint` | no output, exit 0 |
| `npm run check:budgets:self-test` | `# pass 9` / `# fail 0` |
| `npm run check:budgets` | `Dependency-budget check passed.` |
| `npm run check:spec-frontmatter:self-test` | `# pass 11` / `# fail 0` |
| `npm run check:spec-frontmatter` | `Spec-frontmatter check passed.` |
| `npm run check:skill-drift:self-test` | `# pass 29` / `# fail 0` |
| `npm run check:skill-drift` | **FAILS on `base` — expected, see above** |
| `python3 .claude/skills/publish-record/test_publish.py` | `Ran 73 tests` … `OK` |

The expected failure, verbatim (the other three skills stay green):

```
FAIL base — DRIFT
       source of truth : docs/skills/base.md
       embedded copy   : https://raw.githubusercontent.com/npstorey/socrata-mcp-server/main/src/skills/base.ts
       34 line(s) only in the source of truth, 22 only in the embedded copy; first difference at line 175
       lines 405 vs 393, chars 20478 vs 17307
OK   local — in sync (32 lines, 1622 chars)
OK   web — in sync (48 lines, 4764 chars)
OK   web-reference-demo — in sync (21 lines, 1469 chars)
```

Offline proof that the embed on socrata-mcp-server#60 is byte-identical to this branch's source
(`node scripts/check-skill-drift.mjs --source <that branch's worktree>/src/skills`):

```
OK   base — in sync (405 lines, 20478 chars)
OK   local — in sync (32 lines, 1622 chars)
OK   web — in sync (48 lines, 4764 chars)
OK   web-reference-demo — in sync (21 lines, 1469 chars)

Skill-drift check passed — every embedded copy matches its source of truth.
```

## Blast zone

`docs/skills/base.md` only. No other skill document, no `docs/skills/README.md`, no architecture or ADR
doc, no specification or registry surface, no server code, no website file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fhHCFuP71aUUg3bcZFxoE
