### PR TITLE
harness: a call the record states as failed asserts no access (Wave N10 P-H1, #192)

### DIFF
--- a/packages/civic-typed-harness/CHANGELOG.md
+++ b/packages/civic-typed-harness/CHANGELOG.md
@@ -3,6 +3,50 @@
 Factual record of what changed per published version. Section references are
 to the Typed Standards specification unless noted otherwise.
 
+## Unreleased
+
+**A call the record states as failed asserts no access**
+([civic-ai-tools#192](https://github.com/npstorey/civic-ai-tools/issues/192),
+Wave N10 P-H1). Additive: no existing export is removed, no existing caller
+changes, and every golden byte — both vocabulary eras, all eight
+golden-reproduction cases — is unchanged.
+
+- **`ToolCallSummary` can see the rejection.** Two new OPTIONAL fields:
+  `failed?: boolean`, the producer's assertion that the source rejected this
+  call, and `failureKind?: string`, the producer's own open label for why.
+  The harness never interprets the label, and `buildDataSources` never reads
+  it — `failed` is the assertion, `failureKind` only a label on one. A
+  summary carrying neither is exactly the 0.3.1 shape, and absence means
+  "not recorded as failed", never "succeeded".
+- **`buildDataSources` mints nothing from a rejected call.** A call whose
+  summary carries `failed: true` contributes no dataset-keyed entry for the
+  dataset it never read, and marks no aggregate source accessed. Previously
+  the population could not see the failure at all, so a rejected call minted
+  its dataset's entry and, on an aggregate source, marked that source
+  accessed at a timestamp — inside the bytes a publisher signs. The rejected
+  call keeps its POSITION in the walk (calls pair to spans by index), and it
+  remains on the PROV-O graph's tool-call activities and in the caller's own
+  `queries[]`. A source with any non-rejected call is still accessed; a
+  dataset a successful call also read still gets its entry.
+- **The two inert inputs are marked deprecated, not removed.**
+  `buildDataSources`'s `fallbackPortal` — accepted and not consulted since
+  0.3.1 — now also accepts `undefined`, so a caller that has stopped
+  consulting it can stop supplying a value; it stays third of five positional
+  parameters, because dropping a positional parameter is breaking.
+  `ProvenanceInput.portal` becomes optional and carries `@deprecated`;
+  removing it outright would make the reference app's object literal an
+  excess-property error. Both removals wait for a major.
+- **Byte consequence.** A package built from a record that states no failure
+  is byte-identical to one built by 0.3.1 — the walk reaches the new branch
+  only when a summary carries `failed: true`. A package built from a record
+  that DOES state a failure loses the `dataSources` entries that failure
+  never earned; that is the defect being fixed, and the wave re-emits
+  nothing.
+- **Type-level gate.** `src/capture/data-sources.assert.ts` pins the shape at
+  compile time. `tsconfig.json` excludes `src/**/*.test.ts`, so the suite
+  type-checks nothing — a test can drive a field the type does not have and
+  `npm run typecheck` stays green.
+
 ## 0.3.1 — 2026-09-02
 
 **The graph states what the span carried, and states absence as absence**

--- a/packages/civic-typed-harness/src/capture/data-sources.assert.ts
+++ b/packages/civic-typed-harness/src/capture/data-sources.assert.ts
@@ -1,0 +1,47 @@
+// Type-level acceptance gate for the 0.4.0 additive change (civic-ai-tools#192):
+// `ToolCallSummary` can see a rejection the producer recorded, and BOTH new
+// fields are OPTIONAL — a caller that records no outcome passes neither and
+// compiles exactly as it did at 0.3.1.
+//
+// Why a file rather than a test: `tsconfig.json` EXCLUDES `src/**/*.test.ts`,
+// so the suite type-checks nothing. A test can drive a field the type does not
+// have and `npm run typecheck` stays green — which is exactly what happened
+// while this phase's red instrument was the only thing pinning the shape. The
+// type is pinned here instead, mirroring `src/required-config.assert.ts`.
+//
+// Compile-time only: nothing here is exported, and the guard is never invoked.
+
+import { buildDataSources, type ToolCallSummary } from './data-sources.ts';
+
+declare const trace: Record<string, unknown>;
+
+function pinsToolCallSummaryShape(): void {
+  // The 0.3.1 shape is still a ToolCallSummary — both new fields are optional.
+  const unrecorded: ToolCallSummary = { name: 'get_data', args: {} };
+
+  // A recorded outcome is expressible, with or without a producer label.
+  const rejected: ToolCallSummary = { name: 'get_data', args: {}, failed: true };
+  const succeeded: ToolCallSummary = { name: 'get_data', args: {}, failed: false };
+  const labelled: ToolCallSummary = {
+    name: 'get_data',
+    args: {},
+    failed: true,
+    failureKind: 'unavailable',
+  };
+
+  // @ts-expect-error #192 — `failed` is the producer's boolean assertion, never a string
+  const wrongFailedType: ToolCallSummary = { name: 'get_data', args: {}, failed: 'yes' };
+
+  // @ts-expect-error #192 — `failureKind` is an open producer label (string), never a flag
+  const wrongKindType: ToolCallSummary = { name: 'get_data', args: {}, failureKind: true };
+
+  // `fallbackPortal` stays positional third of five for callers that still
+  // pass it, and since 0.4.0 accepts `undefined` from callers that do not.
+  buildDataSources([unrecorded, rejected, succeeded, labelled], trace, 'portal.example', 'now');
+  buildDataSources([unrecorded], trace, undefined, 'now');
+
+  void wrongFailedType;
+  void wrongKindType;
+}
+
+void pinsToolCallSummaryShape;

--- a/packages/civic-typed-harness/src/capture/data-sources.test.ts
+++ b/packages/civic-typed-harness/src/capture/data-sources.test.ts
@@ -436,3 +436,217 @@ test('honest shape: a dataset-keyed call with an injected portal still yields it
   });
   assert.ok(!JSON.stringify(entries).includes('data.run-portal.example'));
 });
+
+// --- A call the record states as failed asserts no access (Wave N10 P-H1) ---
+//
+// RED INSTRUMENT. At 0.3.1 `ToolCallSummary` is `{ name; args }`, so
+// `buildDataSources` cannot see a rejection its caller recorded, and a rejected
+// call reaches BOTH minting branches: the dataset-keyed branch mints an entry
+// for a dataset the call never read, and the aggregate branch marks the source
+// accessed on a call that resolved and nothing more. Both land inside the bytes
+// a publisher signs — the package states an access, at a timestamp, that the
+// record it was built from does not carry.
+//
+// The property: a call the source rejected asserts no access. Scope is
+// `buildDataSources` only — the call is still on the PROV-O graph's tool-call
+// activities, and a caller's own `queries[]` still carries the whole attempt.
+//
+// The two shapes below are the ones in which the assertion CAN fail. A rejected
+// call on a dataset a successful call also read de-duplicates into that call's
+// entry, and an aggregate source with any successful call is accessed however
+// the rejected one is treated: in neither shape could these assertions fail, so
+// neither is the instrument. Both are pinned further down as the converse.
+
+test('shape A: a call recorded as failed mints no entry for its dataset, and the succeeded call keeps its own', () => {
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.city.example', dataset_id: 'abcd-1234' },
+    },
+    {
+      // Recorded as rejected, on a dataset nothing else in this run touched —
+      // the shape in which an entry for it cannot come from anywhere else.
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.city.example', dataset_id: 'efab-5678' },
+      failed: true,
+      failureKind: 'unavailable',
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('socrata', { 'tool.dataset_id': 'abcd-1234', 'tool.portal_domain': 'data.city.example' }),
+    toolSpan('socrata', { 'tool.dataset_id': 'efab-5678', 'tool.portal_domain': 'data.city.example' }),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.run-portal.example', NOW);
+
+  assert.ok(
+    !entries.some((e) => e.datasetId === 'efab-5678'),
+    'a call the record states as failed read no dataset: it may not appear in dataSources',
+  );
+  assert.ok(
+    !JSON.stringify(entries).includes('efab-5678'),
+    'the rejected dataset may not be named anywhere in the emitted entries',
+  );
+  assert.equal(entries.length, 1, 'exactly the succeeded call contributes an entry');
+  assert.deepEqual(entries[0], {
+    sourceId: 'socrata',
+    catalogType: 'socrata',
+    portalUrl: 'https://data.city.example',
+    datasetId: 'abcd-1234',
+    datasetUrl: 'https://data.city.example/d/abcd-1234',
+    accessTimestamp: NOW,
+  });
+});
+
+test('shape B: a call recorded as failed marks no aggregate source accessed', () => {
+  const registry: CivicSourceRegistry = {
+    'city-warehouse': {
+      displayName: 'City Warehouse',
+      agentTitle: 'City Warehouse MCP Server',
+      serverUrl: 'https://mcp.city.example',
+      catalogType: 'warehouse',
+      aggregatePortalUrl: 'https://data.city.example',
+    },
+  };
+  const resolver = (name: string) => (name === 'warehouse_query' ? 'city-warehouse' : undefined);
+  // One call to the source, and it was rejected — the shape in which the
+  // source's accessed-ness can only come from the rejected call.
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'warehouse_query', args: { query: 'noise complaints' }, failed: true, failureKind: 'timeout' },
+  ];
+
+  const entries = buildDataSources(
+    toolCalls,
+    { resourceSpans: [] },
+    'data.run-portal.example',
+    NOW,
+    { resolver, registry, fallbackSourceId: 'city-warehouse' },
+  );
+
+  assert.ok(
+    !entries.some((e) => e.sourceId === 'city-warehouse'),
+    'a call the record states as failed accessed nothing: its aggregate source may not be marked accessed',
+  );
+  assert.equal(entries.length, 0, 'a run whose only call was rejected accessed no data source');
+});
+
+test('shape B on the shipped civic registry: a rejected Data Commons call marks the source accessed nowhere', () => {
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'search_indicators',
+      args: { query: 'median household income' },
+      failed: true,
+      failureKind: 'unavailable',
+    },
+  ];
+  const trace = traceWithToolSpans([toolSpan('data-commons')]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.run-portal.example', NOW);
+
+  assert.equal(entries.length, 0, 'the run reached no source it can state it accessed');
+});
+
+// --- The converse: absent is absent, and a recorded success is a success ---
+
+test('a summary carrying no failure key behaves exactly as it did before the key existed', () => {
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.city.example', dataset_id: 'abcd-1234' },
+    },
+    { name: 'search_indicators', args: { query: 'population' } },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('socrata', { 'tool.dataset_id': 'abcd-1234', 'tool.portal_domain': 'data.city.example' }),
+    toolSpan('data-commons'),
+  ]);
+
+  const withoutKey = buildDataSources(toolCalls, trace, 'data.run-portal.example', NOW);
+  const withExplicitFalse = buildDataSources(
+    toolCalls.map((tc) => ({ ...tc, failed: false })),
+    trace,
+    'data.run-portal.example',
+    NOW,
+  );
+
+  assert.equal(withoutKey.length, 2);
+  assert.equal(
+    JSON.stringify(withExplicitFalse),
+    JSON.stringify(withoutKey),
+    'a recorded success and an unrecorded outcome produce the same entries',
+  );
+});
+
+test('a rejected call on a dataset a successful call also read leaves that entry standing', () => {
+  // The shape Wave N9 P6 drove, pinned here as the shape in which the
+  // rejected-call assertion CANNOT fail: the successful call mints the entry,
+  // so dropping the rejected one changes nothing.
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.city.example', dataset_id: 'abcd-1234' },
+    },
+    {
+      name: 'get_data',
+      args: { type: 'metadata', portal: 'data.city.example', dataset_id: 'abcd-1234' },
+      failed: true,
+      failureKind: 'timeout',
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('socrata', { 'tool.dataset_id': 'abcd-1234', 'tool.portal_domain': 'data.city.example' }),
+    toolSpan('socrata', { 'tool.dataset_id': 'abcd-1234', 'tool.portal_domain': 'data.city.example' }),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.run-portal.example', NOW);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].datasetId, 'abcd-1234', 'the successful call read this dataset, and says so');
+});
+
+test('an aggregate source with one rejected call and one successful call is still accessed', () => {
+  const toolCalls: ToolCallSummary[] = [
+    {
+      name: 'search_indicators',
+      args: { query: 'median household income' },
+      failed: true,
+      failureKind: 'timeout',
+    },
+    {
+      name: 'get_observations',
+      args: { variable_dcid: 'Median_Income_Household', place_dcid: 'geoId/36061' },
+    },
+  ];
+  const trace = traceWithToolSpans([toolSpan('data-commons'), toolSpan('data-commons')]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.run-portal.example', NOW);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].sourceId, 'data-commons');
+  assert.equal(entries[0].portalUrl, 'https://api.datacommons.org/mcp');
+});
+
+test('a rejected call keeps its position: the calls after it still pair with their own spans', () => {
+  // `resolveToolSource` pairs a call to `toolSpans[i]` BY INDEX, so a fix that
+  // filtered the rejected call out of the list before the walk would shift
+  // every later call onto the wrong span. Here call 0 is rejected and resolves
+  // to an aggregate source; call 1 is a dataset-keyed success. A shifted walk
+  // reads span 0 for call 1 and emits the aggregate entry instead.
+  const toolCalls: ToolCallSummary[] = [
+    { name: 'search_indicators', args: { query: 'population' }, failed: true, failureKind: 'unavailable' },
+    {
+      name: 'get_data',
+      args: { type: 'query', portal: 'data.city.example', dataset_id: 'abcd-1234' },
+    },
+  ];
+  const trace = traceWithToolSpans([
+    toolSpan('data-commons'),
+    toolSpan('socrata', { 'tool.dataset_id': 'abcd-1234', 'tool.portal_domain': 'data.city.example' }),
+  ]);
+
+  const entries = buildDataSources(toolCalls, trace, 'data.run-portal.example', NOW);
+
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].sourceId, 'socrata', 'the surviving call kept its own span');
+  assert.equal(entries[0].datasetId, 'abcd-1234');
+});

--- a/packages/civic-typed-harness/src/capture/data-sources.ts
+++ b/packages/civic-typed-harness/src/capture/data-sources.ts
@@ -30,6 +30,22 @@ export type { DataSourceEntry };
 export interface ToolCallSummary {
   name: string;
   args: Record<string, unknown>;
+  /** Did the producer record this call as REJECTED by the source? A call
+   *  recorded as failed asserts no access: it contributes no dataset-keyed
+   *  entry and marks no aggregate source accessed (see `buildDataSources`).
+   *
+   *  Optional, and absent is absent: a producer that records no outcome
+   *  passes neither this nor `failureKind`, and gets exactly the entries it
+   *  got before the fields existed. Absence means "not recorded as failed",
+   *  never "succeeded". Added 0.4.0. */
+  failed?: boolean;
+  /** The producer's own label for why the call was rejected, carried so a
+   *  caller can hand its record through unchanged. An open string with no
+   *  normative vocabulary: the harness never interprets it, and this module
+   *  never reads it. `failed` is the assertion and `failureKind` only a label
+   *  on one — a summary carrying a kind but no `failed` is not treated as a
+   *  rejection. Added 0.4.0. */
+  failureKind?: string;
 }
 
 interface TraceSpan {
@@ -104,14 +120,25 @@ export function resolveToolSource(
  * dataset-keyed entries (first-seen order), then aggregate sources in
  * registry insertion order — matching the reference implementation.
  *
- * `fallbackPortal` is accepted and NOT consulted since 0.3.1: an entry
- * states the portal the call carried, never the run's. The parameter stays
- * in the signature so existing callers keep compiling.
+ * A call the producer recorded as FAILED (`ToolCallSummary.failed`) asserts
+ * no access and contributes nothing on either branch: no dataset-keyed entry
+ * for a dataset it never read, and no accessed-marking of its aggregate
+ * source. It keeps its POSITION in the walk, because calls are paired to
+ * spans by index. The call is still on the PROV-O graph's tool-call
+ * activities and in the caller's own `queries[]` — what it is not is an
+ * assertion, inside signed bytes, that a source was reached at a timestamp.
+ *
+ * @param fallbackPortal DEPRECATED, and inert since 0.3.1: an entry states
+ * the portal the call carried, never the run's. It stays third of five
+ * positional parameters so existing callers keep compiling, and since 0.4.0
+ * it also accepts `undefined`, which is what a caller that has stopped
+ * consulting it should pass. Dropping it is a breaking change and waits for
+ * a major.
  */
 export function buildDataSources(
   toolCalls: ToolCallSummary[],
   trace: Record<string, unknown>,
-  fallbackPortal: string,
+  fallbackPortal: string | undefined,
   now: string,
   options: DataSourceOptions = {},
 ): DataSourceEntry[] {
@@ -125,6 +152,11 @@ export function buildDataSources(
 
   for (let i = 0; i < toolCalls.length; i++) {
     const tc = toolCalls[i];
+    // A call the producer recorded as rejected reached no data, so it mints
+    // no entry on either branch below. The walk keeps its index rather than
+    // filtering the list: `resolveToolSource` pairs a call to `toolSpans[i]`,
+    // and a filtered list would shift every later call onto the wrong span.
+    if (tc.failed) continue;
     const source = resolveToolSource(tc, toolSpans[i], resolver, fallbackSourceId);
     if (isDatasetKeyedSource(source, registry)) {
       const datasetId = tc.args.dataset_id as string | undefined;

--- a/packages/civic-typed-harness/src/capture/provenance.ts
+++ b/packages/civic-typed-harness/src/capture/provenance.ts
@@ -64,10 +64,14 @@ export interface ProvenanceInput {
   /** The run's selected portal. Accepted and NOT consulted by the graph
    *  builder since 0.3.1: the graph states the portal a tool span carried
    *  (`tool.portal_domain`) and states absence as absence — it never
-   *  substitutes the run's portal for one the call did not address. The
-   *  field stays in the type so callers that pass it (the reference app
-   *  does, as an object literal) keep compiling. */
-  portal: string;
+   *  substitutes the run's portal for one the call did not address.
+   *
+   *  @deprecated Inert since 0.3.1 and optional since 0.4.0 — a caller that
+   *  has stopped consulting it should stop passing it. The field stays in
+   *  the type so callers that do pass it (the reference app does, as an
+   *  object literal) keep compiling; removing it outright would make that
+   *  literal an excess-property error, so removal waits for a major. */
+  portal?: string;
 }
 
 /** Instance configuration for the graph build (config-not-constants). */


### PR DESCRIPTION
Wave N10 P-H1 (sprint anchor `npstorey/civic-ai-tools-website#409`) — closes both halves of #192.

**The property.** A call the source rejected asserts no access. Today `buildDataSources` cannot see a
rejection at all — `ToolCallSummary` is `{ name; args }` — so a rejected call reaches both minting
branches: it mints a dataset-keyed entry for a dataset it never read, and on an aggregate source it
marks that source accessed at a timestamp. Both land inside the bytes a publisher signs.

## Diff

```
 packages/civic-typed-harness/CHANGELOG.md          |  44 +++++
 .../src/capture/data-sources.assert.ts             |  47 +++++
 .../src/capture/data-sources.test.ts               | 214 +++++++++++++++++++++
 .../src/capture/data-sources.ts                    |  40 +++-
 .../civic-typed-harness/src/capture/provenance.ts  |  12 +-
 5 files changed, 349 insertions(+), 8 deletions(-)
```

Blast zone: `packages/civic-typed-harness/src/capture/` plus its tests plus a CHANGELOG `Unreleased`
entry. Nothing outside it. **No golden fixture byte changed** —
`git diff origin/main -- packages/civic-typed-harness/src/__fixtures__/` is empty, and the eight
golden-reproduction cases pass unedited.

## The red, first commit

`ea290ee` is the failing instrument; `b67324f` is the fix. At `origin/main` (`fd9afae`) the harness
had no fixture, type field or test containing a rejected call anywhere, so there was no red to
inherit — this creates it. Four tests fail at base:

```
not ok 19 - shape A: a call recorded as failed mints no entry for its dataset, and the succeeded call keeps its own
    error: 'a call the record states as failed read no dataset: it may not appear in dataSources'
    expected: true / actual: false
not ok 20 - shape B: a call recorded as failed marks no aggregate source accessed
    error: 'a call the record states as failed accessed nothing: its aggregate source may not be marked accessed'
    expected: true / actual: false
not ok 21 - shape B on the shipped civic registry: a rejected Data Commons call marks the source accessed nowhere
    error: 'the run reached no source it can state it accessed' — 1 !== 0
not ok 25 - a rejected call keeps its position: the calls after it still pair with their own spans
    2 !== 1
# tests 141 / # pass 137 / # fail 4
```

After the fix: `# tests 141 / # pass 141 / # fail 0`.

**The fixtures are the ones that could fail**, as the contract names them: shape A puts the rejected
`get_data` on a **different** dataset id from the succeeded one, so its entry cannot come from
anywhere else; shape B is a source whose **only** call was rejected. Three converse tests pin the
shapes in which the assertion *cannot* fail — a rejected call on a dataset a successful call also
read, an aggregate source with one rejected and one successful call, and a summary carrying no
failure key at all — and all three are green at base and after.

## What changed

- `ToolCallSummary` gains `failed?: boolean` and `failureKind?: string`, both optional. `failed` is
  the producer's assertion; `failureKind` is an open producer label the harness never interprets and
  this module never reads. A summary carrying a kind but no `failed` is not treated as a rejection.
- `buildDataSources` skips a call carrying `failed: true` on both branches. It keeps the call's
  **position** — `resolveToolSource` pairs a call to `toolSpans[i]`, so filtering the list would shift
  every later call onto the wrong span. Test 25 is the guard on that.
- `src/capture/data-sources.assert.ts` pins the shape at compile time, mirroring
  `src/required-config.assert.ts`. It exists because `tsconfig.json` **excludes** `src/**/*.test.ts`:
  the suite type-checks nothing, so a test can drive a field the type does not have and
  `npm run typecheck` stays green. Probed bidirectionally — making `failed` required yields
  `TS2741`, retyping `failureKind` yields `TS2322` plus an unused-`@ts-expect-error` `TS2578`.

## The inert parameters (minor-safe, per D6 = 0.4.0)

Measured consumers of `buildDataSources`'s `fallbackPortal` (positional third of five) and
`ProvenanceInput.portal`:

| Consumer | `fallbackPortal` | `ProvenanceInput.portal` |
|---|---|---|
| this repo, production code | none | none |
| this repo, tests | `golden-reproduction.test.ts`, `composition-roundtrip.test.ts`, `data-sources.test.ts`, `provenance.test.ts` | same |
| reference app | a thin wrapper re-declaring it as required `string`, one production caller passing the run portal | one object-literal property |
| the other two sibling repositories | none — neither depends on the harness | none |

Both are **inert-and-deprecated**, not removed: `fallbackPortal` widens to `string | undefined` (a
caller that has stopped consulting it can pass `undefined`) and carries the deprecation on its
`@param`; `ProvenanceInput.portal` becomes optional and carries `@deprecated`. Removing either is a
breaking change and is reported as **proposed-major**, not done here.

## Checks

All eleven CI-gated checks green — full output in the phase report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWaGXKnyS27JJfPXwj6pKL
