### PR TITLE
harness: the activity for a rejected call says it was rejected (Wave N10 P-H2, #193)

### DIFF
--- a/packages/civic-typed-harness/CHANGELOG.md
+++ b/packages/civic-typed-harness/CHANGELOG.md
@@ -5,6 +5,52 @@ to the Typed Standards specification unless noted otherwise.
 
 ## Unreleased
 
+**The PROV-O activity for a rejected call says it was rejected**
+([civic-ai-tools#193](https://github.com/npstorey/civic-ai-tools/issues/193),
+Wave N10 P-H2). Additive: no existing export is removed or retyped, and every
+golden byte — both vocabulary eras, all eight golden-reproduction cases — is
+unchanged.
+
+- **Two new activity terms.** `CIVIC_TERM_FAILED` (`civic:failed`) and
+  `CIVIC_TERM_FAILURE_KIND` (`civic:failureKind`) are declared in
+  `src/format/vocabulary.ts` and exported from the package root. A `civic:`
+  property name is vocabulary as much as the namespace it hangs under, so the
+  capture-side builder imports them rather than spelling them; `purity.test.ts`
+  now lists both, which is what makes that a claim able to fail.
+- **`buildProvenanceGraph` reads the span's failure.** A tool span the producer
+  ended with the boolean `error: true` yields a tool-call activity carrying
+  `civic:failed: true`, and `civic:failureKind` with the span's `error.kind`
+  verbatim when it carried one. Previously the builder read nine `tool.*` /
+  `mcp.*` attributes and never asked about the outcome, so a call the source
+  REFUSED and one that answered were the same node with the same description —
+  and, a rejected call having no response hash, the absent data-response entity
+  was the only trace of the rejection in the graph. `error.kind` is the one
+  attribute name across this package and the reference producer.
+- **`error` is the assertion, `error.kind` only a label on one.** A span
+  carrying a kind and no assertion is not a rejection and yields neither key —
+  the posture `ToolCallSummary.failed` / `failureKind` already takes.
+- **A new boolean attribute reader.** The module's string attribute reader
+  returns `stringValue ?? intValue` and cannot see `boolValue` at all, so it
+  returned `undefined` for a span that really did record a rejection.
+  `getBoolAttr` is a separate, strictly-typed reader rather than a widening of
+  the string one: the nine attributes that reader serves are strings by
+  contract, and a truthiness test would read the string `"false"` as an
+  assertion of failure. Only the boolean `true` marks an activity.
+- **The description states no cause.** `dcterms:description` is byte-unchanged
+  — it states what the call WAS, and the marker states how it ended. The
+  classified kind is the only cause the graph will ever carry: the reference
+  producer stopped writing a rejection's raw text onto the span in this same
+  wave, and the builder does not read it back in one layer up.
+- **Byte consequence.** Both terms are spread conditionally and appended after
+  every key the activity already carried, exactly as `civic:durationMs` is. A
+  span that recorded no rejection yields the 0.3.1 key list in the 0.3.1 order,
+  and `civic:failed: false` is never emitted — a producer that stated "not
+  failed" and one that stated nothing must read the same, which is what makes a
+  marker that IS present mean something. A rejected span carries no
+  `tool.duration_ms` from the reference producer today
+  ([civic-ai-tools-website#413](https://github.com/npstorey/civic-ai-tools-website/issues/413)),
+  so `civic:durationMs` does not fire beside the two new keys.
+
 **A call the record states as failed asserts no access**
 ([civic-ai-tools#192](https://github.com/npstorey/civic-ai-tools/issues/192),
 Wave N10 P-H1). Additive: no existing export is removed, no existing caller

--- a/packages/civic-typed-harness/src/capture/provenance.test.ts
+++ b/packages/civic-typed-harness/src/capture/provenance.test.ts
@@ -140,7 +140,11 @@ interface SpanStub {
   spanId?: string;
   startTimeUnixNano?: string;
   endTimeUnixNano?: string;
-  attributes: Array<{ key: string; value: { stringValue?: string; intValue?: string } }>;
+  // `boolValue` is the third OTel value shape (capture/trace.ts) and the one a
+  // rejection arrives in — the reference producer ends a refused call's span
+  // with `error: true`. It is on this stub so a fixture can drive that shape
+  // rather than a string the producer never writes.
+  attributes: Array<{ key: string; value: { stringValue?: string; intValue?: string; boolValue?: boolean } }>;
 }
 
 function traceOf(spans: SpanStub[]): Record<string, unknown> {
@@ -710,4 +714,300 @@ test('honest shape: a span with no tool.name yields a query entity with no civic
   assert.equal(query!['dcterms:description'], 'MCP tool arguments (unknown)');
   const activity = derived.find((n) => n['@id'].includes(':tool-call:'));
   assert.equal(activity!['dcterms:description'], 'MCP tool call (unknown)');
+});
+
+// --- The activity states the rejection (Wave N10 P-H2, civic-ai-tools#193) ---
+//
+// RED INSTRUMENT. At 0.3.1 the graph describes a call the source REFUSED
+// exactly as it describes one that answered — same activity node, same
+// description, no marker — so a reader of the signed graph cannot tell them
+// apart. `buildProvenanceGraph` reads nine `tool.*` / `mcp.*` attributes and
+// never looks at the span's failure at all.
+//
+// HOW THE REJECTION ARRIVES. The reference producer ends a rejected call's
+// span with `error: true` and `error.kind: <ToolFailureKind>`
+// (civic-ai-tools-website `src/lib/model-loop/run-tool-loop.ts`, the catch
+// site). `error.kind` is the one attribute name across both repositories
+// (Wave N10 D5) and `error.message` is gone from that span by the same wave,
+// so the classified kind is the ONLY cause the graph may ever state.
+//
+// `error` is a BOOLEAN, and `TraceBuilder` encodes a boolean as
+// `{ boolValue }` (capture/trace.ts) — a value shape the module's string
+// attribute reader returns `undefined` for. The fixtures below therefore
+// write it as a boolean rather than as the string "true": a fixture that
+// wrote the string would drive a path the producer does not use, and would go
+// green over a reader that cannot see a real rejection.
+//
+// THE PROPERTY. `error` is the ASSERTION and `error.kind` only a LABEL on one
+// — the posture `ToolCallSummary.failed` / `failureKind` already takes. A span
+// carrying a kind and no assertion is not a rejection. A span carrying
+// `error: false` is not a rejection either, and states that by carrying NO
+// marker key at all: a literal `false` inside signed bytes would assert an
+// outcome the producer never stated, and "recorded as not-failed" is not
+// distinguishable from "nothing recorded" once it is written down.
+
+/** A span attribute the producer wrote as a BOOLEAN. */
+function boolAttr(key: string, boolValue: boolean): SpanStub['attributes'][number] {
+  return { key, value: { boolValue } };
+}
+
+/** Two dataset ids so the rejected call addresses a dataset nothing else
+ *  touched — the shape in which an assertion about the rejected call can
+ *  actually fail. Seeded hex opens in the letter range (fixture convention). */
+const ANSWERED_DATASET = 'abcd-1234';
+const REJECTED_DATASET = 'a1b2-c3d4';
+
+/**
+ * The wave's driving shape: in ONE trace, a call the source answered and a
+ * call it REFUSED, on different datasets. Two calls rather than one so that a
+ * builder which marked every activity, or marked the wrong one, fails here.
+ *
+ * The rejected span carries no `tool.response_hash` (there was no response)
+ * and no `tool.duration_ms` — the reference producer measures a duration for
+ * a rejected call and does not write it onto the span
+ * (civic-ai-tools-website#413, out of scope for this phase), so the
+ * conditional `civic:durationMs` simply does not fire. That is the input, not
+ * a thing to compensate for.
+ */
+function answeredAndRejectedTrace(options: {
+  kind?: string;
+  rawText?: string;
+  assertion?: boolean;
+} = {}): Record<string, unknown> {
+  const answered: SpanStub = {
+    name: 'mcp_tool_call',
+    spanId: 'span-answered',
+    startTimeUnixNano: '1000000000',
+    endTimeUnixNano: '2000000000',
+    attributes: attrs({
+      'mcp.source': 'socrata',
+      'tool.name': 'get_data',
+      'tool.operation_type': 'query',
+      'tool.arguments': `{"type":"query","dataset_id":"${ANSWERED_DATASET}","portal":"${RUN_PORTAL}"}`,
+      'tool.dataset_id': ANSWERED_DATASET,
+      'tool.portal_domain': RUN_PORTAL,
+      'tool.response_hash': 'a0b1c2',
+      'tool.duration_ms': '850',
+    }),
+  };
+  const rejected: SpanStub = {
+    name: 'mcp_tool_call',
+    spanId: 'span-rejected',
+    startTimeUnixNano: '3000000000',
+    endTimeUnixNano: '4000000000',
+    attributes: [
+      ...attrs({
+        'mcp.source': 'socrata',
+        'tool.name': 'get_data',
+        'tool.operation_type': 'query',
+        'tool.arguments': `{"type":"query","dataset_id":"${REJECTED_DATASET}","portal":"${RUN_PORTAL}"}`,
+        'tool.dataset_id': REJECTED_DATASET,
+        'tool.portal_domain': RUN_PORTAL,
+        ...(options.kind ? { 'error.kind': options.kind } : {}),
+        ...(options.rawText ? { 'error.message': options.rawText } : {}),
+      }),
+      ...(options.assertion === undefined
+        ? [boolAttr('error', true)]
+        : [boolAttr('error', options.assertion)]),
+    ],
+  };
+  return traceOf([answered, rejected]);
+}
+
+/** The tool-call activity the builder derived from one span. */
+function activityForSpan(nodes: GraphNode[], spanId: string): GraphNode {
+  const urn = `${CIVIC_URN_PREFIX}:${BASE_INPUT.packageId}:tool-call:${spanId}`;
+  const node = nodes.find((n) => n['@id'] === urn);
+  assert.ok(node, `${urn}: the tool-call activity must be on the graph`);
+  return node!;
+}
+
+/** The keys a tool-call activity carried at 0.3.1, in emission order — the
+ *  byte contract. A marker is APPENDED to this list; nothing in it moves. */
+const ACTIVITY_KEYS_0_3_1 = [
+  '@id',
+  '@type',
+  'dcterms:description',
+  'civic:sourceId',
+  'prov:used',
+  'prov:wasAssociatedWith',
+  'prov:startedAtTime',
+  'prov:endedAtTime',
+];
+
+function hasKey(node: GraphNode, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(node, key);
+}
+
+test('the activity states the rejection: a span ended with the failure carries the marker and its classified kind, and the call that answered carries neither', () => {
+  const graph = buildProvenanceGraph(
+    answeredAndRejectedTrace({ kind: 'unavailable' }),
+    BASE_INPUT,
+    CIVICAITOOLS_PROVENANCE_CONFIG,
+  );
+  const nodes = graph['@graph'] as GraphNode[];
+  const rejected = activityForSpan(nodes, 'span-rejected');
+  const answered = activityForSpan(nodes, 'span-answered');
+
+  assert.equal(
+    rejected['civic:failed'],
+    true,
+    'the activity for a span the source refused must state the rejection — without it the graph describes a refused call exactly as it describes one that answered',
+  );
+  assert.equal(
+    rejected['civic:failureKind'],
+    'unavailable',
+    'the classified kind the span carried is stated verbatim — the producer classifies once, the graph does not re-derive',
+  );
+
+  // The two must be TELLABLE APART. This leg is what makes the assertion
+  // above able to fail in the other direction: a builder that marked every
+  // activity would satisfy the first two assertions and fail here.
+  assert.ok(!hasKey(answered, 'civic:failed'), 'the call that answered must carry no failure marker');
+  assert.ok(!hasKey(answered, 'civic:failureKind'), 'the call that answered must carry no failure kind');
+  assert.notDeepEqual(
+    Object.keys(rejected),
+    Object.keys(answered).filter((k) => k !== 'civic:durationMs'),
+    'a reader must be able to tell the two activities apart',
+  );
+});
+
+test('the activity states the rejection: a rejected span that carried no kind states the failure and states no kind', () => {
+  const graph = buildProvenanceGraph(
+    answeredAndRejectedTrace(),
+    BASE_INPUT,
+    CIVICAITOOLS_PROVENANCE_CONFIG,
+  );
+  const rejected = activityForSpan(graph['@graph'] as GraphNode[], 'span-rejected');
+  assert.equal(rejected['civic:failed'], true);
+  assert.ok(
+    !hasKey(rejected, 'civic:failureKind'),
+    'a kind the span did not carry is omitted, never placeholdered with "unknown" — that word is one of the producer\'s four real values',
+  );
+});
+
+test('the activity states the rejection: the marker is appended, leaving every key the activity already carried in its place', () => {
+  const graph = buildProvenanceGraph(
+    answeredAndRejectedTrace({ kind: 'timeout' }),
+    BASE_INPUT,
+    CIVICAITOOLS_PROVENANCE_CONFIG,
+  );
+  const nodes = graph['@graph'] as GraphNode[];
+  assert.deepEqual(
+    Object.keys(activityForSpan(nodes, 'span-answered')),
+    [...ACTIVITY_KEYS_0_3_1, 'civic:durationMs'],
+    'the activity for a call that answered is the 0.3.1 shape, key for key and in order',
+  );
+  assert.deepEqual(
+    Object.keys(activityForSpan(nodes, 'span-rejected')),
+    [...ACTIVITY_KEYS_0_3_1, 'civic:failed', 'civic:failureKind'],
+    'the marker is appended after the keys the activity already carried — insertion order is the hashed byte order',
+  );
+});
+
+test('absent is absent: a span carrying error: false yields an activity with no failure key at all, not a literal false', () => {
+  const graph = buildProvenanceGraph(
+    answeredAndRejectedTrace({ assertion: false, kind: 'timeout' }),
+    BASE_INPUT,
+    CIVICAITOOLS_PROVENANCE_CONFIG,
+  );
+  const node = activityForSpan(graph['@graph'] as GraphNode[], 'span-rejected');
+  assert.ok(
+    !hasKey(node, 'civic:failed'),
+    'a producer that stated "not failed" and a producer that stated nothing must be indistinguishable in the bytes — a literal false asserts an outcome',
+  );
+  assert.ok(!hasKey(node, 'civic:failureKind'), 'no assertion, so no label on one');
+  assert.deepEqual(Object.keys(node), ACTIVITY_KEYS_0_3_1);
+});
+
+test('the kind is a label on the assertion, not the assertion: a span carrying error.kind and no error is not a rejection', () => {
+  const rejectedWithKindOnly: SpanStub = {
+    name: 'mcp_tool_call',
+    spanId: 'span-kind-only',
+    startTimeUnixNano: '1000000000',
+    endTimeUnixNano: '2000000000',
+    attributes: attrs({
+      'mcp.source': 'socrata',
+      'tool.name': 'get_data',
+      'tool.operation_type': 'query',
+      'tool.arguments': '{"type":"query"}',
+      'error.kind': 'unavailable',
+    }),
+  };
+  const graph = buildProvenanceGraph(
+    traceOf([rejectedWithKindOnly]),
+    BASE_INPUT,
+    CIVICAITOOLS_PROVENANCE_CONFIG,
+  );
+  const node = activityForSpan(graph['@graph'] as GraphNode[], 'span-kind-only');
+  assert.ok(!hasKey(node, 'civic:failed'), 'a label with nothing to label is not an assertion of failure');
+  assert.ok(!hasKey(node, 'civic:failureKind'), 'and the label alone is not stated either');
+  assert.deepEqual(Object.keys(node), ACTIVITY_KEYS_0_3_1);
+});
+
+test('the description names no cause the span did not carry: raw text on the span reaches no node the builder derives from it', () => {
+  // The reference producer stopped writing raw error text onto the span in
+  // this same wave, precisely so it could not reach signed bytes. This
+  // fixture puts it back — a hostname and a stack fragment, the shapes such
+  // text actually carries — and demands the builder ignore it. Without the
+  // fixture the assertion could only ever be green.
+  const rawText = 'connect ECONNREFUSED mcp.unreachable.example:8443 at Socket.onError';
+  const graph = buildProvenanceGraph(
+    answeredAndRejectedTrace({ kind: 'unavailable', rawText }),
+    BASE_INPUT,
+    CIVICAITOOLS_PROVENANCE_CONFIG,
+  );
+  const derived = nodesDerivedFromToolSpan(graph['@graph'], BASE_INPUT.packageId, 'span-rejected');
+  for (const node of derived) {
+    assert.ok(
+      !JSON.stringify(node).includes('mcp.unreachable.example'),
+      `${node['@id']}: a node derived from the span names a host out of the source's raw text`,
+    );
+    assert.ok(
+      !JSON.stringify(node).includes('ECONNREFUSED'),
+      `${node['@id']}: a node derived from the span carries the source's raw text`,
+    );
+  }
+  const activity = activityForSpan(graph['@graph'] as GraphNode[], 'span-rejected');
+  assert.equal(
+    activity['dcterms:description'],
+    'MCP tool call: get_data (query)',
+    'the description states what the call WAS; the cause is stated by the classified kind and by nothing else',
+  );
+  assert.equal(activity['civic:failureKind'], 'unavailable', 'the classified kind is the only cause on the node');
+});
+
+test('byte stability: the golden trace carries no rejected call, so its five tool-call activities are what an unconditional marker would move', () => {
+  // This names the driving fixture for the byte-stability criterion. The
+  // golden-parity tests at the top of this file compare the whole graph
+  // against `website-golden.json` byte for byte; an unconditional
+  // `civic:failed: false` would add a key to each of these five activities and
+  // turn every one of them, and all eight golden-reproduction cases, red.
+  const goldenToolSpans = (FIXTURE.trace.resourceSpans[0].scopeSpans[0].spans as SpanStub[]).filter(
+    (s) => s.name === 'mcp_tool_call',
+  );
+  assert.equal(goldenToolSpans.length, 5, 'the golden trace has five tool spans');
+  for (const span of goldenToolSpans) {
+    assert.ok(
+      !span.attributes.some((a) => a.key === 'error' || a.key === 'error.kind'),
+      'no golden tool span carries a failure — this fixture can only exercise the unmarked path',
+    );
+  }
+
+  const graph = buildProvenanceGraph(
+    FIXTURE.trace,
+    FIXTURE.provenanceInput,
+    PRIOR_ERA_REFERENCE_CONFIG,
+  );
+  const activities = (graph['@graph'] as GraphNode[]).filter((n) => n['@id'].includes(':tool-call:'));
+  assert.equal(activities.length, 5);
+  for (const activity of activities) {
+    assert.ok(!hasKey(activity, 'civic:failed'), `${activity['@id']}: no failure was recorded, so no key is emitted`);
+    assert.ok(!hasKey(activity, 'civic:failureKind'), `${activity['@id']}: and no kind either`);
+  }
+  assert.equal(
+    JSON.stringify(graph),
+    JSON.stringify(FIXTURE.provenanceGraph),
+    'a trace that records no failure reproduces the reference bytes exactly',
+  );
 });

--- a/packages/civic-typed-harness/src/capture/provenance.ts
+++ b/packages/civic-typed-harness/src/capture/provenance.ts
@@ -36,6 +36,8 @@ import type { OTelTrace, OTelAttribute } from './trace.ts';
 import {
   CIVIC_VOCABULARY,
   CIVICAITOOLS_PLATFORM_AGENT,
+  CIVIC_TERM_FAILED,
+  CIVIC_TERM_FAILURE_KIND,
   type CivicVocabulary,
   type PlatformAgentConfig,
 } from '../format/vocabulary.ts';
@@ -117,6 +119,31 @@ export const CIVICAITOOLS_PROVENANCE_CONFIG: ProvenanceConfig = {
 function getAttr(attrs: OTelAttribute[], key: string): string | undefined {
   const attr = attrs.find(a => a.key === key);
   return attr?.value?.stringValue ?? attr?.value?.intValue ?? undefined;
+}
+
+/**
+ * Read an attribute the producer wrote as a BOOLEAN.
+ *
+ * `getAttr` above returns `stringValue ?? intValue` and cannot see the third
+ * OTel value shape at all — `TraceBuilder` encodes a boolean as
+ * `{ boolValue }` (trace.ts), so `getAttr(attrs, 'error')` returns `undefined`
+ * for a span the producer really did end with `error: true`. This is a
+ * separate reader rather than a widening of `getAttr` on purpose: the nine
+ * attributes `getAttr` serves are strings by contract and feed hashes,
+ * descriptions and `Number()`, and teaching it a fourth return shape would
+ * change what all nine yield for value shapes nobody has measured.
+ *
+ * The comparison is strict, and only `true` counts. A truthiness test over
+ * `stringValue` would read the string `"false"` as an assertion of failure —
+ * marking a call that ANSWERED as refused, inside bytes a publisher signs.
+ * The cost of the strictness is that a producer encoding this attribute as a
+ * string gets no marker; the reference producer does not, and under-reading a
+ * foreign encoding leaves the graph silent, where over-reading one would make
+ * it lie.
+ */
+function getBoolAttr(attrs: OTelAttribute[], key: string): boolean | undefined {
+  const attr = attrs.find(a => a.key === key);
+  return typeof attr?.value?.boolValue === 'boolean' ? attr.value.boolValue : undefined;
 }
 
 function nanoToIso(nano: string): string {
@@ -425,6 +452,29 @@ export function buildProvenanceGraph(
     // the call. In multi-source analyses each call may target a different
     // agent (e.g. socrata for `get_data`, data-commons for `get_observations`).
     const durationMs = getAttr(span.attributes, 'tool.duration_ms');
+
+    // Did the SOURCE REFUSE this call? Before 0.4.0 the graph never asked, so
+    // a refused call and one that answered were the same node with the same
+    // description — the absence of a data-response entity was the only trace
+    // of the rejection, and absence stated as nothing is not absence stated.
+    //
+    // `error` is the ASSERTION and `error.kind` only a LABEL on one. A span
+    // carrying a kind and no assertion is not a rejection, so the kind is read
+    // and stated only inside the failure branch — the posture
+    // `ToolCallSummary.failed`/`failureKind` already takes on the other input.
+    // `error.kind` is the one attribute name across this package and the
+    // reference producer (Wave N10 D5); neither side invents a second.
+    //
+    // The kind is the ONLY cause this graph will ever state. The producer
+    // stopped writing a rejection's raw text onto the span in the same wave —
+    // that text is authored by the source, can name a host, a port or a stack
+    // frame, and the trace travels inline inside the bytes an instance signs.
+    // Reading it here would put it back one layer up; the classified vocabulary
+    // widens instead. Nor does the description change: it states what the call
+    // WAS, and the marker below states how it ended.
+    const failed = getBoolAttr(span.attributes, 'error');
+    const failureKind = failed === true ? getAttr(span.attributes, 'error.kind') : undefined;
+
     graph.push(
       makeActivityNode(toolCallUrn, {
         // Names the tool only when the span did.
@@ -441,6 +491,17 @@ export function buildProvenanceGraph(
           ? { 'prov:endedAtTime': xsdDateTime(nanoToIso(span.endTimeUnixNano)) }
           : {}),
         ...(durationMs ? { 'civic:durationMs': Number(durationMs) } : {}),
+        // Appended LAST and spread conditionally, exactly as `civic:durationMs`
+        // above is: a span that recorded no rejection yields the key list it
+        // yielded at 0.3.1, in the same order, and property insertion order is
+        // the legacy chain's byte contract. `false` is never emitted — a
+        // producer that stated "not failed" and one that stated nothing must
+        // read the same, which is what makes a marker that IS present mean
+        // something. A rejected span carries no `tool.duration_ms` from the
+        // reference producer today (civic-ai-tools-website#413), so
+        // `civic:durationMs` simply does not fire beside these two.
+        ...(failed === true ? { [CIVIC_TERM_FAILED]: true } : {}),
+        ...(failureKind ? { [CIVIC_TERM_FAILURE_KIND]: failureKind } : {}),
       }),
     );
   }

--- a/packages/civic-typed-harness/src/format/vocabulary.ts
+++ b/packages/civic-typed-harness/src/format/vocabulary.ts
@@ -38,6 +38,48 @@ export const PRIOR_ERA_CIVIC_NS = 'https://civicaitools.org/ns/evidence/';
  *  2026-08-19 settlement. Never emitted for new packages. */
 export const PRIOR_ERA_CIVIC_URN_PREFIX = 'urn:civic-evidence';
 
+// --- Term names ---
+//
+// A `civic:` property name is vocabulary as much as the namespace it hangs
+// under: it is the word a reader of a signed graph interprets, so it is
+// declared here and imported by the builder that emits it, never spelled as a
+// literal inside capture/ (`purity.test.ts` enforces that for the terms below).
+// Both terms are era-independent — the settlement moved the NAMESPACE, not the
+// property names — so they carry no era qualifier and are minted for the first
+// time after it.
+//
+// The settlement-era property names that predate Wave N10 (`civic:sourceId`,
+// `civic:durationMs`, `civic:datasetId` and their siblings) are still inline
+// literals in the capture-side builder. That is a real inconsistency, recorded
+// rather than fixed in passing: moving them is a byte-sensitive change across
+// every golden fixture and belongs to a phase of its own.
+
+/**
+ * `civic:failed` — a tool-call activity whose call the SOURCE REFUSED.
+ *
+ * Emitted with the boolean `true` and only when the producer stated the
+ * rejection; never emitted as `false`. A literal `false` would assert an
+ * outcome, and "recorded as not-failed" must stay indistinguishable from
+ * "nothing recorded" — the same absent-is-absent posture `ToolCallSummary`
+ * takes for `failed`. A reader that finds no key learns that the record
+ * states nothing, which is the truth about every package minted before 0.4.0.
+ */
+export const CIVIC_TERM_FAILED = 'civic:failed';
+
+/**
+ * `civic:failureKind` — the producer's own classified label for WHY a call
+ * carrying {@link CIVIC_TERM_FAILED} was refused.
+ *
+ * An open string with no normative vocabulary here: the harness states the
+ * label verbatim and never interprets or re-derives it. It is a label on an
+ * assertion, not the assertion — a record that carries a kind and no failure
+ * is not a rejection, and the term is emitted only alongside
+ * {@link CIVIC_TERM_FAILED}. The reference producer's four values are
+ * `timeout`, `unavailable`, `not_configured` and `unknown`; a producer with a
+ * wider vocabulary widens this field rather than putting prose in it.
+ */
+export const CIVIC_TERM_FAILURE_KIND = 'civic:failureKind';
+
 /**
  * One era of the civic vocabulary: the two literals plus the emitters bound
  * to them. The vocabulary is not deployment configuration (a deployment does

--- a/packages/civic-typed-harness/src/purity.test.ts
+++ b/packages/civic-typed-harness/src/purity.test.ts
@@ -149,12 +149,26 @@ test('boundary: capture modules define no civic vocabulary (terms live in format
   // records and must stay reproducible), so a capture module could redefine
   // EITHER era and break the boundary the same way. Listing only the era of
   // the day would let the other one through.
+  //
+  // The list also carries TERM NAMES, not only the two namespace roots and the
+  // profile string. A `civic:` property name is vocabulary as much as the
+  // namespace it hangs under: it is the word a reader of a signed graph
+  // interprets, and it belongs beside the namespace that gives it meaning.
+  // Only the terms minted from Wave N10 onward are listed — the settlement-era
+  // property names that predate it (`civic:sourceId`, `civic:durationMs`,
+  // `civic:datasetId` and their siblings) are still inline literals in
+  // capture/provenance.ts, which is a real inconsistency and is recorded as
+  // one rather than fixed here: moving them is a separate, byte-sensitive
+  // change with no phase behind it. Listing a term here is what makes "the
+  // term is declared in format/vocabulary.ts" a claim that can fail.
   const VOCAB_LITERALS = [
     'urn:civic-record', // the id scheme, settlement era
     'urn:civic-evidence', // the id scheme, prior era
     'civicaitools.org/ns/civic', // the civic: namespace, settlement era
     'civicaitools.org/ns/evidence', // the civic: namespace, prior era
     'ai-assisted-analysis/datHere', // the datHere producer profile
+    'civic:failed', // the rejected-call marker (Wave N10, civic-ai-tools#193)
+    'civic:failureKind', // the classified kind that labels it
   ];
   for (const file of shippedSourceFiles().filter((f) => rel(f).startsWith('capture/'))) {
     const code = readFileSync(file, 'utf8');


### PR DESCRIPTION
Wave N10 phase **P-H2**, sprint anchor
[civic-ai-tools-website#409](https://github.com/npstorey/civic-ai-tools-website/issues/409).
Closes #193. Base `24fb69e` (`origin/main`, which already carries P-H1).

## What changed

The PROV-O graph described a call the source **refused** exactly as it described one that
answered — same activity node, same description, no marker. `buildProvenanceGraph` read nine
`tool.*` / `mcp.*` attributes and never asked about the outcome; a rejected call having no
response hash, the absent data-response entity was the only trace of the rejection in the graph,
and absence stated as nothing is not absence stated.

A tool span the producer ended with the boolean `error: true` now yields a tool-call activity
carrying `civic:failed: true`, plus `civic:failureKind` with the span's `error.kind` verbatim when
it carried one. Both terms are declared in `src/format/vocabulary.ts`
(`CIVIC_TERM_FAILED` / `CIVIC_TERM_FAILURE_KIND`) and imported by the builder, and both are spread
conditionally and appended after every key the activity already carried — exactly as
`civic:durationMs` is. D5 ruling A, implemented as ruled.

`error` is the **assertion** and `error.kind` only a **label** on one: a span carrying a kind and
no assertion is not a rejection and yields neither key — the posture
`ToolCallSummary.failed`/`failureKind` already takes. `civic:failed: false` is never emitted: a
producer that stated "not failed" and one that stated nothing must read the same, which is what
makes a marker that IS present mean something.

`dcterms:description` is byte-unchanged. It states what the call WAS; the marker states how it
ended, and the classified kind is the only cause the graph will ever carry.

## Three findings the phase measured

**1. `getAttr` cannot read a boolean, and this is the defect's root.** `provenance.ts:119-122`
returns `stringValue ?? intValue` and ignores `boolValue`. `TraceBuilder` encodes a boolean as
`{ boolValue }` (`capture/trace.ts:62-64`) and the producer writes `'error': true`, so
`getAttr(span.attributes, 'error')` returns `undefined` for a span that really did record a
rejection. Resolved with a **separate strict reader**, `getBoolAttr`, rather than a widening of
`getAttr`: the nine attributes `getAttr` serves are strings by contract and feed hashes,
descriptions and `Number()`. Only the boolean `true` marks an activity — a truthiness test over
`stringValue` would read the string `"false"` as an assertion of failure, marking a call that
**answered** as refused inside bytes a publisher signs.

**2. `purity.test.ts` did not enforce "the term is defined in `format/`", and now does for these
two terms.** Its `VOCAB_LITERALS` list held only the two namespace URIs, the two urn-scheme roots
and the datHere profile string — no property name. `civic:sourceId`, `civic:durationMs` and their
siblings are inline literals in `capture/provenance.ts` and always passed. Criterion 5 as written
therefore could not fail either way. `civic:failed` and `civic:failureKind` are now on that list;
demonstrated red by inlining the literal (see the phase report).

**3. `golden-reproduction.test.ts` cannot detect this change.** All eight envelope cases in
`reference-golden.json` ship an empty trace (`{"resourceSpans": []}`) or a BlobRef — **zero**
`mcp_tool_call` spans between them — so the suite walks no tool-call activity and stays green even
with the marker spread unconditionally. It passes here with no golden byte edited, as required,
but it is not the driving fixture for byte stability. That fixture is **`website-golden.json`**
(five tool-call activities) through `provenance.test.ts`'s two golden-parity tests, and a new
named test pins it. Demonstrated: an unconditional spread turns both parity tests red.

## Tests

Red-first. The first commit's fixtures fail at `24fb69e` (4 failures); the second turns them
green. New coverage: the marker and its kind on a rejected call that answered nothing, beside a
successful call on a different dataset in the same trace; a rejection with no kind; exact key
order for both activities; `error: false` yielding no key; `error.kind` alone yielding no key; raw
error text planted on the span reaching no node the builder derives from it; and the golden trace
named as the byte-stability fixture.

`# pass 148` / `# fail 0`. All eleven CI-gated checks green — full output in the phase report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWaGXKnyS27JJfPXwj6pKL
