### PR TITLE
BLOCKED (Wave N10 P-H3, civic-ai-tools#194): the reader-facing source name is inside the frozen golden bytes

### DIFF
--- a/packages/civic-typed-harness/CHANGELOG.md
+++ b/packages/civic-typed-harness/CHANGELOG.md
@@ -5,6 +5,42 @@ to the Typed Standards specification unless noted otherwise.
 
 ## Unreleased
 
+**The reader-facing source name is measured, not changed**
+([civic-ai-tools#194](https://github.com/npstorey/civic-ai-tools/issues/194),
+Wave N10 P-H3). Tests only: no exported behaviour changes, and every golden
+byte — both vocabulary eras, all eight golden-reproduction cases — is
+unchanged.
+
+- **The change #194 asks for moves frozen golden bytes.** A data response the
+  builder cannot describe by a portal is described by its source's registry
+  `agentTitle` (`Data response from Socrata MCP Server`) — the agent's title,
+  implementation language on a reader-facing surface. Reading the registry's
+  `displayName` instead — the reader-facing name, in the registry beside
+  `agentTitle` since the package's first release — is a one-expression change,
+  and it rewrites two lines inside `__fixtures__/website-golden.json`'s
+  captured graph: the data-commons and boston-opencontext data responses, both
+  on the agent-title branch. Three whole-graph byte-parity assertions read
+  those two lines. A golden fixture is never edited to match new behaviour, so
+  the change waits on a decision about whether those bytes move.
+- **The vocabulary era cannot carry it.** `CivicVocabulary` binds exactly two
+  literals — the `civic:` namespace and the id-scheme prefix
+  (`makeCivicVocabulary(ns, urnPrefix)`) — and both era suites assert the two
+  eras differ by those and by nothing else. A description's wording is neither
+  of them and is not era-scoped: the same prefix is emitted under both eras, so
+  gating it on the era would make prior-era reproduction and settlement-era
+  emission disagree about a reader's wording rather than about an identifier.
+- **Two instruments, both able to fail.** `provenance.test.ts` now pins the
+  agent node's `dcterms:title` to the registry `agentTitle` — those are signed
+  bytes in both golden fixtures and the one thing that does not move under
+  either decision — and names the two golden descriptions at stake, asserting
+  each reads by agent title today and *not* by display name. The sources they
+  drive all carry two distinct registry names, which is what makes the
+  assertions able to fail; a builder changed under either one turns it red.
+- **What holds still either way.** The portal branch
+  (`Data response from data.cityofnewyork.us`) and the unknown-source fallback
+  (`Data response from euro stat`, the raw source id) move under neither
+  decision.
+
 **The PROV-O activity for a rejected call says it was rejected**
 ([civic-ai-tools#193](https://github.com/npstorey/civic-ai-tools/issues/193),
 Wave N10 P-H2). Additive: no existing export is removed or retyped, and every

--- a/packages/civic-typed-harness/src/capture/provenance.test.ts
+++ b/packages/civic-typed-harness/src/capture/provenance.test.ts
@@ -38,6 +38,7 @@ import {
   PRIOR_ERA_CIVIC_URN_PREFIX,
   PRIOR_ERA_CIVIC_VOCABULARY,
 } from '../format/vocabulary.ts';
+import { CIVIC_SOURCE_REGISTRY } from '../format/sources.ts';
 
 const FIXTURE = JSON.parse(
   readFileSync(
@@ -1009,5 +1010,110 @@ test('byte stability: the golden trace carries no rejected call, so its five too
     JSON.stringify(graph),
     JSON.stringify(FIXTURE.provenanceGraph),
     'a trace that records no failure reproduces the reference bytes exactly',
+  );
+});
+
+// --- The two names the graph carries (Wave N10 P-H3, civic-ai-tools#194) ---
+//
+// #194 asks that the data-response description name a source the way a reader
+// would name it ("Data response from Socrata") rather than by the agent that
+// answered ("Data response from Socrata MCP Server"). The registry already
+// carries both names — `displayName` beside `agentTitle` — so the change is
+// three characters of the prefix expression. It is NOT made here: the
+// description is inside `website-golden.json`'s frozen bytes on the
+// agent-title branch, so the change moves golden bytes, and whether those
+// bytes move is the owner's ruling and not this file's. The two instruments
+// below hold the constraint that survives either ruling and measure exactly
+// what is at stake.
+
+test('the agent node states the AGENT, by its registry title — the reader-facing name reaches no node here', () => {
+  // Non-vacuity: this can only catch a change because the registry's two
+  // names differ for this source. A builder that read `displayName` for the
+  // agent node would emit "Socrata" and fail — and those are signed bytes in
+  // both golden fixtures.
+  assert.notEqual(
+    CIVIC_SOURCE_REGISTRY.socrata.displayName,
+    CIVIC_SOURCE_REGISTRY.socrata.agentTitle,
+    'the fixture is shaped so it cannot fail unless the registry carries two distinct names',
+  );
+  const graph = buildProvenanceGraph(
+    traceOf([skillSpan('a0b1c2'), toolSpan('socrata', 'get_data', 'span-agent-title')]),
+    BASE_INPUT,
+    CIVICAITOOLS_PROVENANCE_CONFIG,
+  );
+  const agent = (graph['@graph'] as GraphNode[]).find(
+    (n) => n['@id'] === 'urn:civic-record:mcp-server:socrata',
+  );
+  assert.ok(agent, 'the socrata MCP agent node is expected');
+  assert.equal(agent!['dcterms:title'], 'Socrata MCP Server');
+  assert.equal(
+    agent!['dcterms:title'],
+    CIVIC_SOURCE_REGISTRY.socrata.agentTitle,
+    'the agent node is titled by the registry `agentTitle`, and by nothing else',
+  );
+  assert.notEqual(
+    agent!['dcterms:title'],
+    CIVIC_SOURCE_REGISTRY.socrata.displayName,
+    'the reader-facing name must not reach the agent node — it is inside both golden fixtures’ frozen signed bytes',
+  );
+});
+
+test('byte stability: the golden graph carries two data-response descriptions on the agent-title branch — exactly the frozen bytes a reader-facing prefix would move', () => {
+  // This names the driving fixture for #194's byte question, and it is able
+  // to fail: it asserts the two frozen descriptions read as the registry's
+  // AGENT TITLES today and would read as the registry's DISPLAY NAMES after
+  // the change, on sources whose two names differ. The portal-branch response
+  // and the unknown-source response are named too, as the bytes that must NOT
+  // move under either ruling.
+  const graph = buildProvenanceGraph(
+    FIXTURE.trace,
+    FIXTURE.provenanceInput,
+    PRIOR_ERA_REFERENCE_CONFIG,
+  );
+  const responses = (graph['@graph'] as GraphNode[])
+    .filter((n) => n['@id'].includes(':data:'))
+    .map((n) => ({
+      sourceId: n['civic:sourceId'] as string,
+      description: n['dcterms:description'] as string,
+    }));
+  assert.equal(responses.length, 4, 'the golden trace yields four data responses');
+
+  // The portal branch — untouched by #194 under any ruling.
+  assert.deepEqual(
+    responses.filter((r) => r.description.includes('.')),
+    [{ sourceId: 'socrata', description: 'Data response from data.cityofnewyork.us' }],
+    'exactly one response is described by the portal its span carried',
+  );
+
+  // The agent-title branch on a REGISTRY source: the two bytes at stake.
+  const registryNamed = responses.filter((r) => CIVIC_SOURCE_REGISTRY[r.sourceId] !== undefined
+    && !r.description.includes('.'));
+  assert.deepEqual(
+    registryNamed.map((r) => r.sourceId),
+    ['data-commons', 'boston-opencontext'],
+    'two golden responses are described by a registry source with no portal',
+  );
+  for (const r of registryNamed) {
+    const info = CIVIC_SOURCE_REGISTRY[r.sourceId]!;
+    assert.notEqual(info.displayName, info.agentTitle, `${r.sourceId}: the two registry names must differ for this to be a real measurement`);
+    assert.equal(
+      r.description,
+      `Data response from ${info.agentTitle}`,
+      `${r.sourceId}: the frozen byte reads by AGENT TITLE — reading \`displayName\` here is the #194 change, and it moves this line`,
+    );
+    assert.notEqual(
+      r.description,
+      `Data response from ${info.displayName}`,
+      `${r.sourceId}: stated as the byte the change would write, so this instrument fails the day it does`,
+    );
+  }
+
+  // An UNKNOWN source falls back to the raw id, and holds still under the
+  // change as long as the prefix reads the registry rather than the
+  // capitalising `displayNameForSource` helper.
+  assert.deepEqual(
+    responses.filter((r) => CIVIC_SOURCE_REGISTRY[r.sourceId] === undefined),
+    [{ sourceId: 'euro stat', description: 'Data response from euro stat' }],
+    'the unknown-source response states the raw source id',
   );
 });


### PR DESCRIPTION
## Wave N10 P-H3 — BLOCKED on D4-A's "golden bytes unchanged", with the corrected shape measured

Sprint anchor: npstorey/civic-ai-tools-website#409. Closes nothing — **civic-ai-tools#194 stays open.**

**Outcome: blocked.** D4-A was ruled on a premise that does not hold at `85c5613`. The ruling says
"a second registry field for the reader-facing name, read by the data-response description prefix;
the agent node's `dcterms:title` unchanged; **golden bytes unchanged**." The first two clauses are
achievable — the second registry field already exists — but the third is not: the data-response
description is itself inside `website-golden.json`'s frozen bytes, on the agent-title branch, twice.
Whether those two lines move is an owner ruling, so this PR does not move them.

### What this PR does land (tests + CHANGELOG only, zero behaviour change)

Two instruments in `src/capture/provenance.ts`'s test file, both demonstrated able to fail, plus an
`Unreleased` CHANGELOG entry recording the measurement:

1. **`the agent node states the AGENT, by its registry title`** — pins the agent node's
   `dcterms:title` to the registry `agentTitle`, the one thing that does not move under either
   ruling and the thing that is inside both golden fixtures' signed bytes. Non-vacuous: it asserts
   `displayName !== agentTitle` for the source it drives first, then that the node carries the
   agent title and *not* the display name. Driving `title: info.displayName` in the builder turns
   it red (measured).
2. **`byte stability: the golden graph carries two data-response descriptions on the agent-title
   branch`** — names the driving fixture and the exact bytes at stake: it asserts the golden's four
   data responses split into one portal-branch, two registry-source agent-title-branch, one
   unknown-source, and that each of the two reads `Data response from <agentTitle>` and **not**
   `Data response from <displayName>`. Applying the #194 change turns it red (measured).

### The measurements, in full

**Premise that held.** The second registry field already exists — this phase was never "add a
field". `CivicSourceInfo.displayName` (`format/sources.ts:21`) sits beside `agentTitle` (`:23`) with
values `Socrata` / `Data Commons` / `Boston OpenContext` (`:46, :52, :59`), and
`displayNameForSource` (`:115-121`) already reads it. It has been there since the package's first
release (`604c902`).

**Premise that did not hold — the one that blocks.** The charter (anchor row 3) and D4-A both assume
the description prefix is *outside* the frozen bytes: "rewording the registry title breaks byte
identity; a fix confines itself to the description prefix." It does not. The description prefix is
in the frozen bytes too. Applying the minimal change

```diff
-        : `Data response from ${sourceAgentMap[toolSource]?.title || toolSource}`;
+        : `Data response from ${registry[toolSource]?.displayName || toolSource}`;
```

produces exactly this delta against `__fixtures__/website-golden.json`'s captured graph (413 lines
in, 413 out):

```
L215  frozen : "dcterms:description": "Data response from Google Data Commons MCP Server"
      derived: "dcterms:description": "Data response from Data Commons"
L258  frozen : "dcterms:description": "Data response from Boston OpenContext MCP Server"
      derived: "dcterms:description": "Data response from Boston OpenContext"
differing lines: 2
```

and turns five tests red:

```
not ok 26 - golden parity [prior era]: multi-source trace reproduces the reference graph byte-for-byte
not ok 28 - golden parity [settlement era]: the default vocabulary reproduces the reference graph with exactly the two Appendix J literals substituted
not ok 47 - honest shape: a dataset-keyed span with no tool.portal_domain describes its data response by the source agent title
not ok 48 - honest shape: a dataset-keyed span with a dataset id and no portal states the dataset id and mints no URL
not ok 56 - byte stability: the golden trace carries no rejected call, so its five tool-call activities are what an unconditional marker would move
# tests 150 / # pass 145 / # fail 5
```

47 and 48 are live-derivation tests the fix would legitimately update. **26, 28 and 56 are three
whole-graph byte-parity assertions against the frozen fixture** — they can only be made green by
editing a golden, which is forbidden, or by lifting the expected side.

**The era seam cannot carry it — measured, not inferred.** `CivicVocabulary` is
`makeCivicVocabulary(ns, urnPrefix)`: two literals, the `civic:` namespace and the id-scheme prefix,
with every emitter derived from them. There is no version field, no emission-era discriminator, and
no `version` token anywhere in `format/vocabulary.ts` or `capture/provenance.ts`. Both era suites
assert the eras differ by those two literals **and by nothing else** (`toSettlementEra` substitutes
exactly two strings; the settlement-era test carries its own non-vacuity check). A description's
wording is neither literal and is not era-scoped — the same prefix is emitted under both eras — so
gating it on the era would make prior-era reproduction and settlement-era emission disagree about a
*reader's wording* rather than about an identifier. It would also require editing
`src/format/vocabulary.ts`, which is outside this phase's blast zone.

**Two corroborating findings on fixture vacuity.** `reference-golden.json`'s eight
golden-reproduction cases carry **zero spans of any kind** (not merely no tool-call span) and the
string `Data response` appears in that file 0 times — so all eight staying green under the change is
a vacuous green, not evidence. `website-golden.json` is the only golden that can see this at all.

### The corrected fix-shapes, for the gate

1. **Move the two bytes deliberately in the 0.4.0 minor.** The fixture stays unedited; the three
   byte-parity assertions lift the expected side by a named, non-vacuous substitution the way
   `toSettlementEra` already does, and the CHANGELOG states plainly that 0.4.0 no longer re-derives a
   pre-0.4.0 record's data-response descriptions byte-for-byte while every already-signed package
   remains verifiable exactly as published (the 0.3.1 precedent, which accepted the same trade for
   `civic:toolName`). **Cost:** it contradicts D4-A's third clause and narrows a claim every release
   note since 0.3.0 has repeated verbatim — "every golden byte … unchanged". That is an owner call,
   which is why it is not in this PR.
2. **D4-B — the app maps titles at render time** (N11). Zero harness bytes move; the frozen fixture
   and every byte-parity assertion are untouched. This is the only shape that satisfies D4-A's third
   clause as written, and it was the option D4 ruled against.
3. **Defer #194 to Wave N11**, the charter's own fallback for this row.

Shapes that are *not* available: editing a golden fixture (forbidden, and a golden edited to match
new behaviour proves nothing); an additive key on the data-response entity (the golden exercises the
exact branch, so any additive key fires there and moves bytes too); and "add the second registry
field" (already done, and not what blocks).

### Checks

`npm ci` first. All green at `ce48830`.

| Check | Result |
|---|---|
| `npm run build` | exit 0, `tsc -p tsconfig.json` echo and nothing after |
| `npm test` | `# tests 150` / `# pass 150` / `# fail 0` |
| `npm run typecheck` | no output, exit 0 |
| `npm run lint` | no output, exit 0 |
| `npm run check:budgets:self-test` | `# pass 9` / `# fail 0` |
| `npm run check:budgets` | `Dependency-budget check passed.` |
| `npm run check:spec-frontmatter:self-test` | `# pass 11` / `# fail 0` |
| `npm run check:spec-frontmatter` | `Spec-frontmatter check passed.` |
| `npm run check:skill-drift:self-test` | `# pass 29` / `# fail 0` |
| `npm run check:skill-drift` | `Skill-drift check passed — every embedded copy matches its source of truth.` |
| `python3 .claude/skills/publish-record/test_publish.py` | `Ran 73 tests … OK` |

Baseline at `85c5613` was `# pass 148 / # fail 0`; this branch adds two tests and no behaviour.

### Blast zone

`packages/civic-typed-harness/CHANGELOG.md` and
`packages/civic-typed-harness/src/capture/provenance.test.ts`. Nothing else — no source file, no
fixture, no sibling repository, no `docs/architecture/`. `src/capture/provenance.ts` and
`src/format/sources.ts` are byte-identical to `85c5613`.

Model: Opus 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWaGXKnyS27JJfPXwj6pKL
