### PR TITLE
release: civic-typed-harness 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1524,7 +1524,7 @@
     },
     "packages/civic-typed-harness": {
       "name": "@typedstandards/civic-typed-harness",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "@typedstandards/produce-core": "^0.3.0 || ^0.4.0"

--- a/packages/civic-typed-harness/CHANGELOG.md
+++ b/packages/civic-typed-harness/CHANGELOG.md
@@ -3,7 +3,30 @@
 Factual record of what changed per published version. Section references are
 to the Typed Standards specification unless noted otherwise.
 
-## Unreleased
+## 0.4.0 — 2026-09-04
+
+Minor: two optional input fields are added and no existing export is removed
+or retyped. `fallbackPortal` and `ProvenanceInput.portal`, inert since 0.3.1,
+are widened and deprecated rather than dropped — removing either is breaking
+and waits for a major.
+
+**What this release claims about golden bytes, and what it does not.** Every
+golden byte is unchanged — both vocabulary eras, all eight
+golden-reproduction cases, and `__fixtures__/website-golden.json`. That
+sentence has appeared in every release note since 0.3.0, and it is narrower
+than it reads: **`__fixtures__/reference-golden.json` carries no spans at
+all** — `spanId` and `scopeSpans` each occur zero times across its eight
+cases, whose traces are empty `resourceSpans` arrays or BlobRefs. So those
+eight cases are green for anything the tool-span loop does, including the
+rejection marker this release adds, and their green is not evidence about it.
+
+`website-golden.json` is the only golden fixture that exercises span-derived
+output: five tool-call activities and four data-response descriptions. It is
+the fixture that proves this release's byte-stability claim, and the one the
+conditional spread of `civic:failed` was measured against — driven red by
+making that spread unconditional, which moves it. Read
+[civic-ai-tools#199](https://github.com/npstorey/civic-ai-tools/issues/199)
+before citing a green golden suite as evidence about the graph builder.
 
 **The reader-facing source name is measured, not changed**
 ([civic-ai-tools#194](https://github.com/npstorey/civic-ai-tools/issues/194),

--- a/packages/civic-typed-harness/package.json
+++ b/packages/civic-typed-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typedstandards/civic-typed-harness",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "Civic-domain harness for Typed Standards evidence packages — the DOMAIN layer of the ADR-0021 format/domain line: civic PROV-O vocabulary and provenance builder, datHere envelope-policy derivations, and the capture machinery (trace builder, skill-metadata extraction, data-source population, adversarial rubric core). Derives; @typedstandards/produce-core assembles.",
   "license": "MIT",
   "author": "Nathan Storey",


### PR DESCRIPTION
**Release PR for `@typedstandards/civic-typed-harness` 0.4.0.** Wave N10's hub lane (sprint anchor `civic-ai-tools-website#409`). The cut is the owner's; this PR prepares it.

## What changed

Three files, and nothing else:

| File | Change |
|---|---|
| `packages/civic-typed-harness/package.json` | `0.3.1` → `0.4.0` |
| `packages/civic-typed-harness/CHANGELOG.md` | `## Unreleased` resolved to `## 0.4.0 — 2026-09-04`, **entries verbatim**, plus a release-level lead |
| `package-lock.json` | one line — see below |

**Lockfile diff, read before pushing:** exactly one line, the bumped package's own `version` entry under `packages/civic-typed-harness`. Nothing else moved, no sibling package version appears, no dependency resolution changed.

```diff
     "packages/civic-typed-harness": {
       "name": "@typedstandards/civic-typed-harness",
-      "version": "0.3.1",
+      "version": "0.4.0",
```

## Why minor

Two optional input fields are added (`ToolCallSummary.failed`, `ToolCallSummary.failureKind`) and no existing export is removed or retyped. `fallbackPortal` (positional third of five) and `ProvenanceInput.portal` were chartered to be *dropped*; both are **widened and deprecated instead**, because removing either is breaking and this is a minor. Removal waits for a major. That correction is recorded in the 0.4.0 entries.

## What this release claims about golden bytes — and what it does not

The lead paragraph added to the 0.4.0 entry states this deliberately, at the owner's instruction, because the standing claim is narrower than it reads.

"Every golden byte unchanged — both vocabulary eras, all eight golden-reproduction cases" has appeared in every release note since 0.3.0. Measured during this wave:

- **`__fixtures__/reference-golden.json` carries no spans at all.** `spanId` and `scopeSpans` each occur **zero** times across its eight cases, whose traces are empty `resourceSpans` arrays or BlobRefs.
- Therefore those eight cases stay green for **anything** the tool-span loop does — including the `civic:failed` / `civic:failureKind` marker this release adds. Their green is not evidence about it.
- **`website-golden.json` is the only golden fixture that exercises span-derived output** — five tool-call activities, four data-response descriptions. It is what actually proves this release's byte-stability claim, and the conditional spread of `civic:failed` was measured against it: driven red by making the spread unconditional, which moves it.

This has already cost twice in one wave (P-H2's byte-stability check was contracted against the vacuous fixture; P-H3 watched all eight cases stay green while two lines of `website-golden.json` moved), and 0.3.1 cited that fixture for a `civic:toolName` claim it could not support. Filed as #199.

## What shipped in 0.4.0

- **#196 (P-H1)** — `buildDataSources` reads `failed`. A call the producer recorded as rejected mints no dataset-keyed entry and marks no aggregate source accessed. The suppression `continue`s inside the indexed loop, because calls pair to spans **by index** and filtering the list would shift every later call onto the wrong span.
- **#198 (P-H2)** — the PROV-O activity for a rejected call carries `civic:failed` and `civic:failureKind`, conditionally spread like `civic:durationMs`, defined in `format/vocabulary.ts`. `civic:failed: false` is never emitted. A separate strict boolean reader was added rather than widening `getAttr`, because a truthiness test over `stringValue` would read the string `"false"` as an assertion of failure — marking a call that answered as refused, inside signed bytes.
- **#200 (P-H3)** — measurement and guards only, no behaviour. **#194 is deferred to Wave N11**: its change moves frozen golden bytes and the vocabulary has no version seam to carry it.
- **#201 (P-H4)** — specification §8.1.8, and the spec's own revision **v0.1.8** (tag `v0.1.8-typed-standards-spec`, cut at `938c334`).

## After merge

The owner publishes from a **detached worktree at the merge SHA**; the seat hands that block after reading the merge from disk. Verified by `npm view @typedstandards/civic-typed-harness@0.4.0 dist.shasum`.

Once 0.4.0 is on npm, the website's **P4** takes the pin — the deploy-path phase — retires `rejectedCallStandIn`, and moves `harness-pin.test.ts`'s exclusive ceiling deliberately with the floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GWaGXKnyS27JJfPXwj6pKL
